### PR TITLE
Return parser errors from transform functions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,12 @@ fn main() {
     };
 
     let transforms = parse_transforms();
-    let output = transform_string(&source, transforms.as_ref());
+    let output = match transform_string(&source, transforms.as_ref()) {
+        Ok(output) => output,
+        Err(err) => {
+            eprintln!("failed to parse {}: {}", path, err);
+            process::exit(1);
+        }
+    };
     print!("{}", output);
 }
-


### PR DESCRIPTION
## Summary
- propagate `ParseError` from `transform_string`, `transform_ruff_ast`, and `transform_min_ast` instead of panicking
- exit gracefully in CLI when parsing fails

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfbdcefdbc8324a6c2b348af2c05a6