### PR TITLE
Add minimal desugared AST and transformation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use ruff_python_ast::visitor::transformer::walk_body;
-use ruff_python_ast::{self as ast, Expr, Mod, ModModule, Pattern, Stmt};
+use ruff_python_ast::{self as ast, Expr, ModModule, Pattern, Stmt};
 use ruff_python_codegen::{Generator, Stylist};
 use ruff_python_parser::{parse_module, ParseError};
 use ruff_text_size::TextRange;
@@ -16,6 +16,7 @@ mod for_loop;
 mod gen;
 mod import;
 mod literal;
+pub mod min_ast;
 mod multi_target;
 mod operator;
 mod raise;
@@ -264,7 +265,7 @@ pub fn transform_ruff_ast(
 pub fn transform_min_ast(
     source: &str,
     transforms: Option<&HashSet<String>>,
-) -> Result<Mod, ParseError> {
+) -> Result<min_ast::Module, ParseError> {
     transform_ruff_ast(source, transforms).map(Into::into)
 }
 

--- a/tests/min_ast.rs
+++ b/tests/min_ast.rs
@@ -1,0 +1,47 @@
+use diet_python::min_ast::{Arg, ExprNode, FunctionDef, Module, Parameter, StmtNode};
+use diet_python::transform_min_ast;
+
+#[test]
+fn builds_minimal_ast() {
+    let src = "async def f(x, *a, y=True, **k):\n    await g(x, *a, y=y, **k)\n    return (True, False)\n";
+    let module = transform_min_ast(src, None).unwrap();
+    let expected = Module {
+        body: vec![StmtNode::FunctionDef(FunctionDef {
+            name: "f".to_string(),
+            params: vec![
+                Parameter::Positional {
+                    name: "x".to_string(),
+                    default: None,
+                },
+                Parameter::VarArg { name: "a".to_string() },
+                Parameter::KwOnly {
+                    name: "y".to_string(),
+                    default: Some(ExprNode::Name("True".to_string())),
+                },
+                Parameter::KwArg { name: "k".to_string() },
+            ],
+            body: vec![
+                StmtNode::Expr(ExprNode::Await(Box::new(ExprNode::Call {
+                    func: Box::new(ExprNode::Name("g".to_string())),
+                    args: vec![
+                        Arg::Positional(ExprNode::Name("x".to_string())),
+                        Arg::Starred(ExprNode::Name("a".to_string())),
+                        Arg::Keyword {
+                            name: "y".to_string(),
+                            value: ExprNode::Name("y".to_string()),
+                        },
+                        Arg::KwStarred(ExprNode::Name("k".to_string())),
+                    ],
+                }))),
+                StmtNode::Return {
+                    value: Some(ExprNode::Tuple(vec![
+                        ExprNode::Name("True".to_string()),
+                        ExprNode::Name("False".to_string()),
+                    ])),
+                },
+            ],
+            is_async: true,
+        })],
+    };
+    assert_eq!(module, expected);
+}


### PR DESCRIPTION
## Summary
- extend minimal AST with tuple literals and explicit parameter/argument variants
- represent booleans as names and reject complex numbers
- ignore `dp_intrinsics` imports, panicking on other modules

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc7910b748324aa48a3c77ec0a83c