### PR TITLE
feat(web): persist input in URL

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,19 @@ async function run() {
   const output = document.getElementById('output');
   function update() {
     output.value = transform(input.value);
+    const params = new URLSearchParams(window.location.search);
+    if (input.value) {
+      params.set('src', input.value);
+    } else {
+      params.delete('src');
+    }
+    const query = params.toString();
+    history.replaceState(null, '', query ? `?${query}` : window.location.pathname);
+  }
+  const params = new URLSearchParams(window.location.search);
+  const initial = params.get('src');
+  if (initial !== null) {
+    input.value = initial;
   }
   input.addEventListener('input', update);
   update();


### PR DESCRIPTION
## Summary
- keep textarea contents in `src` query param via history.replaceState
- restore textarea from `src` param on load

## Testing
- `pytest`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c19e9462b88324a4b90bb20dcff89b