### PR TITLE
Add transform selection controls to WASM demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
 name = "diet-python"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "regex",
  "ruff_python_ast",
  "ruff_python_codegen",
@@ -216,6 +217,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
+js-sys = "0.3"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/web/index.html
+++ b/web/index.html
@@ -4,30 +4,48 @@
 <meta charset="utf-8" />
 <title>diet-python WASM demo</title>
 <style>
-body { margin:0; height:100vh; display:flex; }
+body { margin:0; height:100vh; display:flex; flex-direction:column; }
+#controls { padding:10px; }
+#editors { flex:1; display:flex; }
 textarea, .CodeMirror { flex:1; font-family: monospace; padding:10px; border:none; height:100%; }
 .CodeMirror-readonly { background:#f0f0f0; }
 </style>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.css" />
 </head>
 <body>
-<textarea id="input" placeholder="Paste Python code here"></textarea>
-<textarea id="output" readonly></textarea>
+<div id="controls"></div>
+<div id="editors">
+  <textarea id="input" placeholder="Paste Python code here"></textarea>
+  <textarea id="output" readonly></textarea>
+</div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/mode/python/python.min.js"></script>
 <script type="module">
-import init, { transform } from "./pkg/diet_python.js";
+import init, { transform_selected, available_transforms } from "./pkg/diet_python.js";
 
 async function run() {
   await init();
+  const controls = document.getElementById('controls');
   const input = document.getElementById('input');
   const output = document.getElementById('output');
   const inputEditor = CodeMirror.fromTextArea(input, { lineNumbers: true, mode: 'python' });
   const outputEditor = CodeMirror.fromTextArea(output, { lineNumbers: true, mode: 'python', readOnly: true });
   inputEditor.setSize(null, '100%');
   outputEditor.setSize(null, '100%');
+  available_transforms().forEach(name => {
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = name;
+    checkbox.checked = true;
+    checkbox.addEventListener('change', update);
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode(name));
+    controls.appendChild(label);
+  });
   function update() {
-    outputEditor.setValue(transform(inputEditor.getValue()));
+    const selected = Array.from(controls.querySelectorAll('input:checked')).map(cb => cb.value);
+    outputEditor.setValue(transform_selected(inputEditor.getValue(), selected));
     const params = new URLSearchParams(window.location.search);
     const src = inputEditor.getValue();
     if (src) {


### PR DESCRIPTION
## Summary
- export available transform names and a helper to run only a selected subset from the WASM module
- add checkbox controls to the web demo to choose transforms and keep the output editor read-only
- include `js-sys` for WASM builds

## Testing
- `cargo test`
- `cargo check --target wasm32-unknown-unknown`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a16dfff48324a9b286b552cebe09