### PR TITLE
Add lazy ternary expression transform

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -106,3 +106,8 @@ def import_(name, spec, fromlist=None, level=0):
     return builtins.__import__(name, globals_dict, {}, fromlist, level)
 
 
+def if_expr(cond, body, orelse):
+    cond_val = truth(cond)
+    return body() if cond_val else orelse()
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ use transform::multi_target::MultiTargetRewriter;
 use transform::operator::OperatorRewriter;
 use transform::raise::RaiseRewriter;
 use transform::simple_expr::SimpleExprTransformer;
+use transform::ternary::TernaryRewriter;
 use transform::truthy::TruthyRewriter;
 use transform::try_except::TryExceptRewriter;
 use transform::with::WithRewriter;
@@ -51,6 +52,7 @@ const TRANSFORM_NAMES: &[&str] = &[
     "truthy",
     "try_except",
     "operator",
+    "ternary",
     "simple_expr",
     "flatten",
 ];
@@ -146,6 +148,10 @@ fn apply_transforms(module: &mut ModModule, transforms: Option<&HashSet<String>>
     if run("operator") {
         let op_transformer = OperatorRewriter::new();
         walk_body(&op_transformer, &mut module.body);
+    }
+    if run("ternary") {
+        let ternary_transformer = TernaryRewriter::new();
+        walk_body(&ternary_transformer, &mut module.body);
     }
     if run("simple_expr") {
         let simple_expr_transformer = SimpleExprTransformer::new();

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod multi_target;
 pub(crate) mod operator;
 pub(crate) mod raise;
 pub(crate) mod simple_expr;
+pub(crate) mod ternary;
 pub(crate) mod truthy;
 pub(crate) mod try_except;
 pub(crate) mod with;

--- a/src/transform/ternary.rs
+++ b/src/transform/ternary.rs
@@ -1,0 +1,82 @@
+use ruff_python_ast::visitor::transformer::{walk_expr, Transformer};
+use ruff_python_ast::{self as ast, Expr};
+
+pub struct TernaryRewriter;
+
+impl TernaryRewriter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Transformer for TernaryRewriter {
+    fn visit_expr(&self, expr: &mut Expr) {
+        walk_expr(self, expr);
+        if let Expr::If(ast::ExprIf {
+            test, body, orelse, ..
+        }) = expr
+        {
+            let test_expr = *test.clone();
+            let body_expr = *body.clone();
+            let orelse_expr = *orelse.clone();
+            *expr = crate::py_expr!(
+                "
+__dp__.if_expr({cond:expr}, lambda: {body:expr}, lambda: {orelse:expr})
+",
+                cond = test_expr,
+                body = body_expr,
+                orelse = orelse_expr,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ruff_python_ast::visitor::transformer::walk_body;
+    use ruff_python_codegen::{Generator, Stylist};
+    use ruff_python_parser::parse_module;
+
+    fn rewrite(source: &str) -> String {
+        let parsed = parse_module(source).expect("parse error");
+        let tokens = parsed.tokens().clone();
+        let mut module = parsed.into_syntax();
+        let rewriter = TernaryRewriter::new();
+        walk_body(&rewriter, &mut module.body);
+        let stylist = Stylist::from_tokens(&tokens, source);
+        let mut output = String::new();
+        for stmt in &module.body {
+            let snippet = Generator::from(&stylist).stmt(stmt);
+            output.push_str(&snippet);
+            output.push_str(stylist.line_ending().as_str());
+        }
+        output
+    }
+
+    #[test]
+    fn rewrites_if_expr() {
+        let cases = [
+            (
+                r#"
+a if b else c
+"#,
+                r#"
+__dp__.if_expr(b, lambda: a, lambda: c)
+"#,
+            ),
+            (
+                r#"
+(a + 1) if f() else (b + 2)
+"#,
+                r#"
+__dp__.if_expr(f(), lambda: a + 1, lambda: b + 2)
+"#,
+            ),
+        ];
+        for (input, expected) in cases {
+            let output = rewrite(input);
+            assert_eq!(output.trim(), expected.trim());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `if_expr` helper in `__dp__` to evaluate ternary branches lazily
- rewrite ternary expressions to use `__dp__.if_expr`
- register the new transform in the pipeline
- drop passing the condition value into each branch lambda

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4fb680434832480fd1102aaf00f96