### PR TITLE
Rewrite BoolOp with lazy RHS evaluation

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -111,3 +111,11 @@ def if_expr(cond, body, orelse):
     return body() if cond_val else orelse()
 
 
+def or_expr(left, right):
+    return left if truth(left) else right()
+
+
+def and_expr(left, right):
+    return right() if truth(left) else left
+
+


### PR DESCRIPTION
## Summary
- rewrite boolean operations to call `__dp__.or_expr` and `__dp__.and_expr` with RHS lambdas
- add runtime helpers for short-circuiting boolean expressions
- adjust tests for the new boolean operation transformation

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c50df448508324b4e4e47dbeff862c