### PR TITLE
Move walk_expr to end of visit_expr

### DIFF
--- a/src/transform/gen.rs
+++ b/src/transform/gen.rs
@@ -61,10 +61,10 @@ impl Transformer for GeneratorRewriter {
 
     fn visit_expr(&self, expr: &mut Expr) {
         if rewrite_comprehension(self, expr) {
+            walk_expr(self, expr);
             return;
         }
 
-        walk_expr(self, expr);
         if let Expr::Generator(gen) = expr {
             let first_iter_expr = gen.generators.first().unwrap().iter.clone();
 
@@ -145,6 +145,8 @@ def {func:id}({param:id}):
                 func = func_name.as_str()
             );
         }
+
+        walk_expr(self, expr);
     }
 }
 


### PR DESCRIPTION
## Summary
- visit_expr now applies transformations before walking children
- generator transform defers walking until after potential rewrites

## Testing
- `cargo test`
- `./scripts/run_cpython_tests.sh test_bool` *(fails: diet-python failed for multiple stdlib modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c52bb185648324bbaea1742d14ba3c