### PR TITLE
refactor: unify loop and match rewrites

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,24 +23,18 @@ use transform::assert::AssertRewriter;
 use transform::class_def::ClassDefRewriter;
 use transform::decorator::DecoratorRewriter;
 use transform::expr::ExprRewriter;
-use transform::for_loop::ForLoopRewriter;
 use transform::gen::GeneratorRewriter;
-use transform::match_case::MatchCaseRewriter;
 use transform::truthy::TruthyRewriter;
-use transform::try_except::TryExceptRewriter;
 use transform::with::WithRewriter;
 
 const TRANSFORM_NAMES: &[&str] = &[
     "gen",
     "with",
-    "for_loop",
     "assert",
     "decorator",
     "class_def",
-    "match_case",
     "import",
     "truthy",
-    "try_except",
     "expr",
     "flatten",
 ];
@@ -77,10 +71,6 @@ fn apply_transforms(module: &mut ModModule, transforms: Option<&HashSet<String>>
         let with_transformer = WithRewriter::new();
         walk_body(&with_transformer, &mut module.body);
     }
-    if run("for_loop") {
-        let for_transformer = ForLoopRewriter::new();
-        walk_body(&for_transformer, &mut module.body);
-    }
     if run("assert") {
         let assert_transformer = AssertRewriter::new();
         walk_body(&assert_transformer, &mut module.body);
@@ -93,10 +83,6 @@ fn apply_transforms(module: &mut ModModule, transforms: Option<&HashSet<String>>
         let class_def_transformer = ClassDefRewriter::new();
         walk_body(&class_def_transformer, &mut module.body);
     }
-    if run("match_case") {
-        let match_transformer = MatchCaseRewriter::new();
-        walk_body(&match_transformer, &mut module.body);
-    }
     if run("import") {
         let import_rewriter = transform::import::ImportRewriter::new();
         walk_body(&import_rewriter, &mut module.body);
@@ -104,10 +90,6 @@ fn apply_transforms(module: &mut ModModule, transforms: Option<&HashSet<String>>
     if run("truthy") {
         let truthy_transformer = TruthyRewriter::new();
         walk_body(&truthy_transformer, &mut module.body);
-    }
-    if run("try_except") {
-        let try_transformer = TryExceptRewriter::new();
-        walk_body(&try_transformer, &mut module.body);
     }
     if run("expr") {
         let expr_transformer = ExprRewriter::new();

--- a/src/transform/try_except.rs
+++ b/src/transform/try_except.rs
@@ -1,127 +1,111 @@
 use std::cell::Cell;
 
-use ruff_python_ast::visitor::transformer::{walk_stmt, Transformer};
 use ruff_python_ast::{self as ast, Expr, Stmt};
 
-pub struct TryExceptRewriter {
-    count: Cell<usize>,
-}
-
-impl TryExceptRewriter {
-    pub fn new() -> Self {
-        Self {
-            count: Cell::new(0),
+pub fn rewrite(stmt: &mut Stmt, count: &Cell<usize>) -> bool {
+    if let Stmt::Try(ast::StmtTry {
+        body,
+        handlers,
+        orelse,
+        finalbody,
+        is_star,
+        ..
+    }) = stmt
+    {
+        if handlers.is_empty() {
+            return false;
         }
-    }
-}
 
-impl Transformer for TryExceptRewriter {
-    fn visit_stmt(&self, stmt: &mut Stmt) {
-        walk_stmt(self, stmt);
+        let id = count.get() + 1;
+        count.set(id);
+        let exc_name = format!("_dp_exc_{}", id);
 
-        if let Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            is_star,
-            ..
-        }) = stmt
-        {
-            if handlers.is_empty() {
-                return;
+        let body_stmts = std::mem::take(body);
+        let orelse_stmts = std::mem::take(orelse);
+        let final_stmts = std::mem::take(finalbody);
+        let handlers_vec = std::mem::take(handlers);
+
+        let exc_assign = crate::py_stmt!(
+            "
+{exc:id} = __dp__.current_exception()",
+            exc = exc_name.as_str(),
+        );
+        let exc_expr = crate::py_expr!("{exc:id}", exc = exc_name.as_str());
+
+        let mut processed: Vec<(Option<Expr>, Vec<Stmt>)> = Vec::new();
+        for handler in handlers_vec {
+            let ast::ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
+                type_,
+                name,
+                body,
+                ..
+            }) = handler;
+            let mut body_stmts = body;
+            if let Some(name) = name {
+                let assign = crate::py_stmt!(
+                    "{name:id} = {exc:id}",
+                    name = name.id.as_str(),
+                    exc = exc_name.as_str(),
+                );
+                body_stmts.insert(0, assign);
             }
+            processed.push((type_.map(|e| *e), body_stmts));
+        }
 
-            let id = self.count.get() + 1;
-            self.count.set(id);
-            let exc_name = format!("_dp_exc_{}", id);
-
-            let body_stmts = std::mem::take(body);
-            let orelse_stmts = std::mem::take(orelse);
-            let final_stmts = std::mem::take(finalbody);
-            let handlers_vec = std::mem::take(handlers);
-
-            let exc_assign = crate::py_stmt!(
-                "
-{exc:id} = __dp__.current_exception()
-",
-                exc = exc_name.as_str(),
-            );
-            let exc_expr = crate::py_expr!("{exc:id}", exc = exc_name.as_str());
-
-            let mut processed: Vec<(Option<Expr>, Vec<Stmt>)> = Vec::new();
-            for handler in handlers_vec {
-                let ast::ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
-                    type_,
-                    name,
-                    body,
-                    ..
-                }) = handler;
-                let mut body_stmts = body;
-                if let Some(name) = name {
-                    let assign = crate::py_stmt!(
-                        "{name:id} = {exc:id}",
-                        name = name.id.as_str(),
-                        exc = exc_name.as_str(),
-                    );
-                    body_stmts.insert(0, assign);
-                }
-                processed.push((type_.map(|e| *e), body_stmts));
-            }
-
-            let mut new_body = vec![exc_assign];
-            let mut chain: Vec<Stmt> = vec![crate::py_stmt!("raise")];
-            for (type_, body) in processed.into_iter().rev() {
-                chain = if let Some(t) = type_ {
-                    vec![crate::py_stmt!(
-                        "
+        let mut new_body = vec![exc_assign];
+        let mut chain: Vec<Stmt> = vec![crate::py_stmt!("raise")];
+        for (type_, body) in processed.into_iter().rev() {
+            chain = if let Some(t) = type_ {
+                vec![crate::py_stmt!(
+                    "
 if __dp__.isinstance({exc:expr}, {typ:expr}):
     {body:stmt}
 else:
-    {next:stmt}
-",
-                        exc = exc_expr.clone(),
-                        typ = t,
-                        body = body,
-                        next = chain,
-                    )]
-                } else {
-                    body
-                };
-            }
-            new_body.extend(chain);
+    {next:stmt}",
+                    exc = exc_expr.clone(),
+                    typ = t,
+                    body = body,
+                    next = chain,
+                )]
+            } else {
+                body
+            };
+        }
+        new_body.extend(chain);
 
-            let mut try_stmt = crate::py_stmt!(
-                "
+        let mut try_stmt = crate::py_stmt!(
+            "
 try:
     {body:stmt}
 except:
-    {handler:stmt}
-",
-                body = body_stmts,
-                handler = new_body,
-            );
+    {handler:stmt}",
+            body = body_stmts,
+            handler = new_body,
+        );
 
-            if let Stmt::Try(ast::StmtTry {
-                orelse,
-                finalbody,
-                is_star: star,
-                ..
-            }) = &mut try_stmt
-            {
-                *orelse = orelse_stmts;
-                *finalbody = final_stmts;
-                *star = *is_star;
-            }
-
-            *stmt = try_stmt;
+        if let Stmt::Try(ast::StmtTry {
+            orelse,
+            finalbody,
+            is_star: star,
+            ..
+        }) = &mut try_stmt
+        {
+            *orelse = orelse_stmts;
+            *finalbody = final_stmts;
+            *star = *is_star;
         }
+
+        *stmt = try_stmt;
+        true
+    } else {
+        false
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::transform::expr::ExprRewriter;
     use crate::assert_flatten_eq;
     use ruff_python_ast::visitor::transformer::walk_body;
     use ruff_python_parser::parse_module;
@@ -129,7 +113,7 @@ mod tests {
     fn rewrite_try(source: &str) -> Vec<Stmt> {
         let parsed = parse_module(source).expect("parse error");
         let mut module = parsed.into_syntax();
-        let rewriter = TryExceptRewriter::new();
+        let rewriter = ExprRewriter::new();
         walk_body(&rewriter, &mut module.body);
         module.body
     }
@@ -146,8 +130,8 @@ except E as e:
 try:
     f()
 except:
-    _dp_exc_1 = __dp__.current_exception()
-    if __dp__.isinstance(_dp_exc_1, E):
+    _dp_exc_1 = getattr(__dp__, "current_exception")()
+    if getattr(__dp__, "isinstance")(_dp_exc_1, E):
         e = _dp_exc_1
         g(e)
     else:
@@ -171,8 +155,8 @@ except:
 try:
     f()
 except:
-    _dp_exc_1 = __dp__.current_exception()
-    if __dp__.isinstance(_dp_exc_1, E):
+    _dp_exc_1 = getattr(__dp__, "current_exception")()
+    if getattr(__dp__, "isinstance")(_dp_exc_1, E):
         h()
     else:
         g()
@@ -181,3 +165,4 @@ except:
         assert_flatten_eq!(output, expected);
     }
 }
+


### PR DESCRIPTION
## Summary
- drop standalone for-loop, try/except, and match-case rewriter structs
- rely on `ExprRewriter` for lowering loops, try blocks, and matches
- adjust tests and transform dispatch to use the unified path

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c59bae33f88324a8ed4ad1981981f4