### PR TITLE
Implement basic string interpolation rewriting

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -86,6 +86,16 @@ use ruff_text_size::TextRange;
 use serde_json::Value;
 use std::{cell::RefCell, collections::HashMap};
 
+pub(crate) fn make_tuple(elts: Vec<Expr>) -> Expr {
+    Expr::Tuple(ast::ExprTuple {
+        node_index: ast::AtomicNodeIndex::default(),
+        range: TextRange::default(),
+        elts,
+        ctx: ast::ExprContext::Load,
+        parenthesized: false,
+    })
+}
+
 pub(crate) enum PlaceholderKind {
     Expr,
     Stmt,

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -7,4 +7,5 @@ pub(crate) mod rewrite_import;
 pub(crate) mod rewrite_match_case;
 pub(crate) mod rewrite_try_except;
 pub(crate) mod rewrite_with;
+pub(crate) mod rewrite_string;
 pub(crate) mod truthy;

--- a/src/transform/rewrite_string.rs
+++ b/src/transform/rewrite_string.rs
@@ -1,0 +1,98 @@
+use crate::template::make_tuple;
+use ruff_python_ast::{self as ast, Expr};
+
+fn join_parts(parts: Vec<Expr>) -> Expr {
+    if parts.len() == 1 {
+        parts.into_iter().next().unwrap()
+    } else {
+        let tuple = make_tuple(parts);
+        crate::py_expr!(
+            r#"
+"".join({tuple:expr})
+"#,
+            tuple = tuple,
+        )
+    }
+}
+
+fn rewrite_elements(elements: &ast::InterpolatedStringElements) -> Expr {
+    let mut parts = Vec::new();
+    for element in elements.iter() {
+        match element {
+            ast::InterpolatedStringElement::Literal(lit) => {
+                parts.push(crate::py_expr!(
+                    "
+{literal:literal}
+",
+                    literal = lit.value.as_ref(),
+                ));
+            }
+            ast::InterpolatedStringElement::Interpolation(interp) => {
+                let value = (*interp.expression).clone();
+                parts.push(crate::py_expr!(
+                    "
+str({value:expr})
+",
+                    value = value,
+                ));
+            }
+        }
+    }
+    join_parts(parts)
+}
+
+pub fn rewrite_fstring(expr: ast::ExprFString) -> Expr {
+    let mut parts = Vec::new();
+    for part in expr.value.iter() {
+        match part {
+            ast::FStringPart::Literal(lit) => {
+                parts.push(crate::py_expr!(
+                    "
+{literal:literal}
+",
+                    literal = lit.value.as_ref(),
+                ));
+            }
+            ast::FStringPart::FString(f) => {
+                parts.push(rewrite_elements(&f.elements));
+            }
+        }
+    }
+    join_parts(parts)
+}
+
+pub fn rewrite_tstring(expr: ast::ExprTString) -> Expr {
+    let mut parts = Vec::new();
+    for t in expr.value.iter() {
+        parts.push(rewrite_elements(&t.elements));
+    }
+    join_parts(parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_util::assert_transform_eq;
+
+    #[test]
+    fn desugars_fstring() {
+        let input = r#"
+f"x={x}"
+"#;
+        let expected = r#"
+getattr("", "join")(("x=", str(x)))
+"#;
+        assert_transform_eq(input, expected);
+    }
+
+    #[test]
+    fn desugars_tstring() {
+        let input = r#"
+t"x={x}"
+"#;
+        let expected = r#"
+getattr("", "join")(("x=", str(x)))
+"#;
+        assert_transform_eq(input, expected);
+    }
+}
+


### PR DESCRIPTION
## Summary
- move tuple construction helper into `template.rs`
- rewrite string interpolation to join tuple segments with `"".join`
- update expression rewriting to use shared tuple helper

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c661ee96e083248b6ec5386587abb8