### PR TITLE
docs: note internal _dp prefix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,4 @@
 - preserve type hints
 - only allow import star when at unconditional top level
 - investigate failing CPython tests: test_frozen, test_importlib
+- ensure all internals are prefixed with _dp, and rewrite to disallow user code from accessing them


### PR DESCRIPTION
## Summary
- add TODO to prefix internals with `_dp` and restrict user access

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c674cd6728832498ccafddd6f35b7c