### PR TITLE
Rewrite parameterless lambdas and add import-star option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,7 @@ mod template;
 mod test_util;
 mod transform;
 
-use transform::expr::ExprRewriter;
-use transform::truthy::TruthyRewriter;
+use transform::{expr::ExprRewriter, truthy::TruthyRewriter, Options};
 
 fn should_skip(source: &str) -> bool {
     source
@@ -28,10 +27,10 @@ fn should_skip(source: &str) -> bool {
         .is_some_and(|line| line.contains("diet-python: disabled"))
 }
 
-fn apply_transforms(module: &mut ModModule) {
+fn apply_transforms(module: &mut ModModule, options: Options) {
     // Lower `for` loops, expand generators and lambdas, and replace
     // `__dp__.<name>` calls with `getattr` in a single pass.
-    let expr_transformer = ExprRewriter::new();
+    let expr_transformer = ExprRewriter::new(options);
     expr_transformer.rewrite_body(&mut module.body);
 
     // Collapse `py_stmt!` templates after all rewrites.
@@ -63,7 +62,7 @@ pub fn transform_str_to_str_exec(source: &str) -> Result<String, ParseError> {
 /// Transform the source code and return the resulting Ruff AST.
 pub fn transform_str_to_ruff(source: &str) -> Result<ModModule, ParseError> {
     let mut module = parse_module(source)?.into_syntax();
-    apply_transforms(&mut module);
+    apply_transforms(&mut module, Options::default());
     Ok(module)
 }
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -9,3 +9,16 @@ pub(crate) mod rewrite_try_except;
 pub(crate) mod rewrite_with;
 pub(crate) mod rewrite_string;
 pub(crate) mod truthy;
+
+#[derive(Clone, Copy)]
+pub struct Options {
+    pub allow_import_star: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            allow_import_star: true,
+        }
+    }
+}

--- a/src/transform/rewrite_match_case.rs
+++ b/src/transform/rewrite_match_case.rs
@@ -295,8 +295,10 @@ match x:
         b()
 "#;
         let expected = r#"
+def _dp_lambda_1():
+    return cond
 _dp_match_1 = x
-if getattr(__dp__, "and_expr")(getattr(__dp__, "eq")(_dp_match_1, 1), lambda: cond):
+if getattr(__dp__, "and_expr")(getattr(__dp__, "eq")(_dp_match_1, 1), _dp_lambda_1):
     a()
 else:
     b()
@@ -314,8 +316,10 @@ match x:
         b()
 "#;
         let expected = r#"
+def _dp_lambda_1():
+    return getattr(__dp__, "eq")(_dp_match_1, 2)
 _dp_match_1 = x
-if getattr(__dp__, "or_expr")(getattr(__dp__, "eq")(_dp_match_1, 1), lambda: getattr(__dp__, "eq")(_dp_match_1, 2)):
+if getattr(__dp__, "or_expr")(getattr(__dp__, "eq")(_dp_match_1, 1), _dp_lambda_1):
     a()
 else:
     b()
@@ -392,8 +396,14 @@ match x:
         c()
 "#;
         let expected = r#"
+def _dp_lambda_3():
+    return hasattr(_dp_match_1, getattr(__dp__, "getitem")(getattr(C, "__match_args__"), 1))
+def _dp_lambda_2():
+    return getattr(__dp__, "and_expr")(getattr(__dp__, "eq")(getattr(_dp_match_1, getattr(__dp__, "getitem")(getattr(C, "__match_args__"), 0)), 1), _dp_lambda_3)
+def _dp_lambda_1():
+    return getattr(__dp__, "and_expr")(hasattr(_dp_match_1, getattr(__dp__, "getitem")(getattr(C, "__match_args__"), 0)), _dp_lambda_2)
 _dp_match_1 = x
-if getattr(__dp__, "and_expr")(isinstance(_dp_match_1, C), lambda: getattr(__dp__, "and_expr")(hasattr(_dp_match_1, getattr(__dp__, "getitem")(getattr(C, "__match_args__"), 0)), lambda: getattr(__dp__, "and_expr")(getattr(__dp__, "eq")(getattr(_dp_match_1, getattr(__dp__, "getitem")(getattr(C, "__match_args__"), 0)), 1), lambda: hasattr(_dp_match_1, getattr(__dp__, "getitem")(getattr(C, "__match_args__"), 1))))):
+if getattr(__dp__, "and_expr")(isinstance(_dp_match_1, C), _dp_lambda_1):
     b = getattr(_dp_match_1, getattr(__dp__, "getitem")(getattr(C, "__match_args__"), 1))
     a()
 else:

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import subprocess
+import textwrap
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_parameterless_lambda(tmp_path):
+    module = tmp_path / "lambda.py"
+    module.write_text(
+        textwrap.dedent(
+            """
+            fn = lambda: 1
+            """
+        )
+    )
+    result = subprocess.run(
+        ["cargo", "run", "--quiet", "--", str(module)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "def _dp_lambda_1()" in result.stdout


### PR DESCRIPTION
## Summary
- rewrite all lambda expressions, even when no parameters
- add transform `Options` with `allow_import_star` to control `from X import *`
- test transformer handles parameterless lambdas and import-star option

## Testing
- `cargo test --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c675edab6483249feb2745d7eb9601