### PR TITLE
Add optional __dp__ import flag to transform options

### DIFF
--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -2,8 +2,8 @@ use ruff_python_ast::visitor::transformer::walk_body;
 use ruff_python_ast::{comparable::ComparableStmt, Stmt};
 use ruff_python_parser::parse_module;
 
-use crate::transform::truthy::TruthyRewriter;
-use crate::{ruff_ast_to_string, transform_str_to_ruff};
+use crate::transform::{truthy::TruthyRewriter, Options};
+use crate::{ruff_ast_to_string, transform_str_to_ruff_with_options};
 
 pub(crate) enum TransformPhase {
     Core,
@@ -11,7 +11,8 @@ pub(crate) enum TransformPhase {
 }
 
 pub(crate) fn assert_transform_eq_ex(actual: &str, expected: &str, phase: TransformPhase) {
-    let mut module = transform_str_to_ruff(actual).unwrap();
+    let mut module =
+        transform_str_to_ruff_with_options(actual, Options::for_test()).unwrap();
     if matches!(phase, TransformPhase::Full) {
         crate::template::flatten(&mut module.body);
         let truthy_transformer = TruthyRewriter::new();

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -13,12 +13,23 @@ pub(crate) mod truthy;
 #[derive(Clone, Copy)]
 pub struct Options {
     pub allow_import_star: bool,
+    pub inject_import: bool,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
             allow_import_star: true,
+            inject_import: true,
+        }
+    }
+}
+
+impl Options {
+    pub fn for_test() -> Self {
+        Self {
+            allow_import_star: false,
+            inject_import: false,
         }
     }
 }

--- a/src/transform/rewrite_import.rs
+++ b/src/transform/rewrite_import.rs
@@ -134,7 +134,13 @@ x = 1
         let input = r#"
 from a import *
 "#;
-        let output = rewrite_source(input, Options { allow_import_star: true });
+        let output = rewrite_source(
+            input,
+            Options {
+                allow_import_star: true,
+                inject_import: false,
+            },
+        );
         assert_eq!(output.trim(), "from a import *");
     }
 
@@ -144,6 +150,12 @@ from a import *
         let input = r#"
 from a import *
 "#;
-        let _ = rewrite_source(input, Options { allow_import_star: false });
+        let _ = rewrite_source(
+            input,
+            Options {
+                allow_import_star: false,
+                inject_import: false,
+            },
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add `inject_import` flag to transform Options and `for_test` constructor
- inject `__dp__` based on option when building transforms
- use `Options::for_test` in test utilities

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f87f1f708324a30a358349c7772f