### PR TITLE
Add lowering scaffolding for statement transforms

### DIFF
--- a/src/transform/lower.rs
+++ b/src/transform/lower.rs
@@ -1,0 +1,228 @@
+use std::cell::Cell;
+
+use ruff_python_ast::{self as ast, Expr, ModModule, Stmt};
+
+use super::unnest_expr::{unnest_expr, unnest_exprs};
+use super::Options;
+
+pub struct Namer {
+    pub counter: Cell<usize>,
+}
+
+impl Namer {
+    pub fn new() -> Self {
+        Self {
+            counter: Cell::new(0),
+        }
+    }
+
+    pub fn fresh(&self, prefix: &str) -> String {
+        let id = self.counter.get();
+        self.counter.set(id + 1);
+        format!("{prefix}_{id}")
+    }
+}
+
+pub struct Context {
+    pub namer: Namer,
+    pub options: Options,
+}
+
+pub fn lower_module(ctx: &Context, module: ModModule) -> ModModule {
+    ModModule {
+        body: lower_stmts(ctx, module.body),
+        ..module
+    }
+}
+
+pub fn lower_stmts(ctx: &Context, stmts: Vec<Stmt>) -> Vec<Stmt> {
+    let mut result = Vec::new();
+    for stmt in stmts {
+        result.extend(lower_stmt(ctx, stmt));
+    }
+    result
+}
+
+fn unnest_expr_prepend(ctx: &Context, prepend: &mut Vec<Stmt>, expr: Expr) -> Expr {
+    let (expr, mut stmts) = unnest_expr(ctx, expr);
+    prepend.append(&mut stmts);
+    expr
+}
+
+fn unnest_exprs_prepend(ctx: &Context, prepend: &mut Vec<Stmt>, exprs: Vec<Expr>) -> Vec<Expr> {
+    let (exprs, mut stmts) = unnest_exprs(ctx, exprs);
+    prepend.append(&mut stmts);
+    exprs
+}
+
+pub fn walk_stmt(ctx: &Context, stmt: Stmt) -> Vec<Stmt> {
+    let mut prepend = vec![];
+    let stmt = match stmt {
+        ast::Stmt::FunctionDef(mut s) => {
+            s.body = lower_stmts(ctx, s.body);
+            ast::Stmt::FunctionDef(s)
+        }
+        ast::Stmt::ClassDef(mut s) => {
+            s.body = lower_stmts(ctx, s.body);
+            ast::Stmt::ClassDef(s)
+        }
+        ast::Stmt::Return(mut s) => {
+            if let Some(value) = s.value.take() {
+                let value = unnest_expr_prepend(ctx, &mut prepend, *value);
+                s.value = Some(Box::new(value));
+            }
+            ast::Stmt::Return(s)
+        }
+        ast::Stmt::Delete(mut s) => {
+            s.targets = unnest_exprs_prepend(ctx, &mut prepend, s.targets);
+            ast::Stmt::Delete(s)
+        }
+        ast::Stmt::TypeAlias(mut s) => {
+            let name = unnest_expr_prepend(ctx, &mut prepend, *s.name);
+            s.name = Box::new(name);
+            s.value = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.value));
+            ast::Stmt::TypeAlias(s)
+        }
+        ast::Stmt::Assign(mut s) => {
+            let (value, mut stmts) = unnest_expr(ctx, *s.value);
+            prepend.append(&mut stmts);
+            s.value = Box::new(value);
+            s.targets = unnest_exprs_prepend(ctx, &mut prepend, s.targets);
+            ast::Stmt::Assign(s)
+        }
+        ast::Stmt::AugAssign(mut s) => {
+            s.value = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.value));
+            s.target = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.target));
+            ast::Stmt::AugAssign(s)
+        }
+        ast::Stmt::AnnAssign(mut s) => {
+            if let Some(value) = s.value.take() {
+                let value = unnest_expr_prepend(ctx, &mut prepend, *value);
+                s.value = Some(Box::new(value));
+            }
+            s.annotation = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.annotation));
+            s.target = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.target));
+            ast::Stmt::AnnAssign(s)
+        }
+        ast::Stmt::For(mut s) => {
+            s.iter = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.iter));
+            s.target = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.target));
+            s.body = lower_stmts(ctx, s.body);
+            s.orelse = lower_stmts(ctx, s.orelse);
+            ast::Stmt::For(s)
+        }
+        ast::Stmt::While(mut s) => {
+            s.test = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.test));
+            s.body = lower_stmts(ctx, s.body);
+            s.orelse = lower_stmts(ctx, s.orelse);
+            ast::Stmt::While(s)
+        }
+        ast::Stmt::If(mut s) => {
+            s.test = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.test));
+            s.body = lower_stmts(ctx, s.body);
+            for clause in &mut s.elif_else_clauses {
+                if let Some(test) = clause.test.take() {
+                    clause.test = Some(unnest_expr_prepend(ctx, &mut prepend, test));
+                }
+                clause.body = lower_stmts(ctx, std::mem::take(&mut clause.body));
+            }
+            ast::Stmt::If(s)
+        }
+        ast::Stmt::With(mut s) => {
+            for item in &mut s.items {
+                let context_expr = item.context_expr.clone();
+                item.context_expr = unnest_expr_prepend(ctx, &mut prepend, context_expr);
+                if let Some(vars) = item.optional_vars.take() {
+                    item.optional_vars = Some(Box::new(unnest_expr_prepend(ctx, &mut prepend, *vars)));
+                }
+            }
+            s.body = lower_stmts(ctx, s.body);
+            ast::Stmt::With(s)
+        }
+        ast::Stmt::Match(mut s) => {
+            s.subject = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.subject));
+            for case in &mut s.cases {
+                if let Some(guard) = case.guard.take() {
+                    case.guard = Some(Box::new(unnest_expr_prepend(ctx, &mut prepend, *guard)));
+                }
+                case.body = lower_stmts(ctx, std::mem::take(&mut case.body));
+            }
+            ast::Stmt::Match(s)
+        }
+        ast::Stmt::Raise(mut s) => {
+            if let Some(exc) = s.exc.take() {
+                s.exc = Some(Box::new(unnest_expr_prepend(ctx, &mut prepend, *exc)));
+            }
+            if let Some(cause) = s.cause.take() {
+                s.cause = Some(Box::new(unnest_expr_prepend(ctx, &mut prepend, *cause)));
+            }
+            ast::Stmt::Raise(s)
+        }
+        ast::Stmt::Try(mut s) => {
+            s.body = lower_stmts(ctx, s.body);
+            s.orelse = lower_stmts(ctx, s.orelse);
+            s.finalbody = lower_stmts(ctx, s.finalbody);
+            for ast::ExceptHandler::ExceptHandler(handler) in &mut s.handlers {
+                if let Some(type_) = handler.type_.take() {
+                    handler.type_ = Some(Box::new(unnest_expr_prepend(ctx, &mut prepend, *type_)));
+                }
+                handler.body = lower_stmts(ctx, std::mem::take(&mut handler.body));
+            }
+            ast::Stmt::Try(s)
+        }
+        ast::Stmt::Assert(mut s) => {
+            s.test = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.test));
+            if let Some(msg) = s.msg.take() {
+                s.msg = Some(Box::new(unnest_expr_prepend(ctx, &mut prepend, *msg)));
+            }
+            ast::Stmt::Assert(s)
+        }
+        ast::Stmt::Import(s) => ast::Stmt::Import(s),
+        ast::Stmt::ImportFrom(s) => ast::Stmt::ImportFrom(s),
+        ast::Stmt::Global(s) => ast::Stmt::Global(s),
+        ast::Stmt::Nonlocal(s) => ast::Stmt::Nonlocal(s),
+        ast::Stmt::Expr(mut s) => {
+            s.value = Box::new(unnest_expr_prepend(ctx, &mut prepend, *s.value));
+            ast::Stmt::Expr(s)
+        }
+        ast::Stmt::Pass(s) => ast::Stmt::Pass(s),
+        ast::Stmt::Break(s) => ast::Stmt::Break(s),
+        ast::Stmt::Continue(s) => ast::Stmt::Continue(s),
+        ast::Stmt::IpyEscapeCommand(s) => ast::Stmt::IpyEscapeCommand(s),
+    };
+
+    prepend.push(stmt);
+    prepend
+}
+
+pub fn lower_stmt(ctx: &Context, stmt: Stmt) -> Vec<Stmt> {
+    walk_stmt(ctx, stmt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::assert_ast_eq;
+    use ruff_python_parser::parse_module;
+
+    #[test]
+    fn lowers_binop_expr() {
+        let input = r#"
+a = (1 + 2) + (3 + 4)
+"#;
+        let module = parse_module(input).unwrap().into_syntax();
+        let ctx = Context {
+            namer: Namer::new(),
+            options: Options::for_test(),
+        };
+        let lowered = lower_module(&ctx, module);
+        let expected = r#"
+_dp_tmp_0 = 1 + 2
+_dp_tmp_1 = 3 + 4
+_dp_tmp_2 = _dp_tmp_0 + _dp_tmp_1
+a = _dp_tmp_2
+"#;
+        let expected = parse_module(expected).unwrap().into_syntax();
+        assert_ast_eq(&lowered.body, &expected.body);
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,4 +1,7 @@
 pub(crate) mod expr;
+pub(crate) mod lower;
+pub(crate) mod unnest_expr;
+pub(crate) mod unnest;
 pub(crate) mod rewrite_assert;
 pub(crate) mod rewrite_class_def;
 pub(crate) mod rewrite_decorator;

--- a/src/transform/unnest.rs
+++ b/src/transform/unnest.rs
@@ -1,0 +1,63 @@
+use ruff_python_ast::visitor::transformer::{walk_stmt, Transformer};
+use ruff_python_ast::Stmt;
+
+use super::lower::Context;
+use super::unnest_expr::UnnestExprTransformer;
+
+pub struct UnnestTransformer<'a> {
+    pub ctx: &'a Context,
+}
+
+impl<'a> UnnestTransformer<'a> {
+    pub fn new(ctx: &'a Context) -> Self {
+        Self { ctx }
+    }
+
+    pub fn visit_stmts(&self, body: &mut Vec<Stmt>) {
+        let mut result = Vec::new();
+        for mut stmt in std::mem::take(body) {
+            let transformer = UnnestExprTransformer::new(self.ctx);
+            walk_stmt(&transformer, &mut stmt);
+            walk_stmt(self, &mut stmt);
+            let mut stmts = transformer.stmts.take();
+            result.append(&mut stmts);
+            result.push(stmt);
+        }
+        *body = result;
+    }
+}
+
+impl<'a> Transformer for UnnestTransformer<'a> {}
+
+pub fn unnest_stmts(ctx: &Context, mut stmts: Vec<Stmt>) -> Vec<Stmt> {
+    let transformer = UnnestTransformer::new(ctx);
+    transformer.visit_stmts(&mut stmts);
+    stmts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::assert_ast_eq;
+    use ruff_python_parser::parse_module;
+    use super::super::lower::{Namer};
+    use super::super::Options;
+
+    #[test]
+    fn unnest_binop() {
+        let input = r#"
+a = (1 + 2) + (3 + 4)
+"#;
+        let module = parse_module(input).unwrap().into_syntax();
+        let ctx = Context { namer: Namer::new(), options: Options::for_test() };
+        let body = unnest_stmts(&ctx, module.body);
+        let expected = r#"
+_dp_tmp_0 = 1 + 2
+_dp_tmp_1 = 3 + 4
+_dp_tmp_2 = _dp_tmp_0 + _dp_tmp_1
+a = _dp_tmp_2
+"#;
+        let expected = parse_module(expected).unwrap().into_syntax();
+        assert_ast_eq(&body, &expected.body);
+    }
+}

--- a/src/transform/unnest_expr.rs
+++ b/src/transform/unnest_expr.rs
@@ -1,0 +1,72 @@
+use std::cell::RefCell;
+
+use ruff_python_ast::{Expr, Stmt};
+use ruff_python_ast::visitor::transformer::{walk_expr, Transformer};
+
+use super::lower::Context;
+
+fn is_simple(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Name(_)
+            | Expr::NumberLiteral(_)
+            | Expr::StringLiteral(_)
+            | Expr::BytesLiteral(_)
+            | Expr::BooleanLiteral(_)
+            | Expr::NoneLiteral(_)
+            | Expr::EllipsisLiteral(_)
+    )
+}
+
+pub struct UnnestExprTransformer<'a> {
+    pub ctx: &'a Context,
+    pub stmts: RefCell<Vec<Stmt>>,
+}
+
+impl<'a> UnnestExprTransformer<'a> {
+    pub fn new(ctx: &'a Context) -> Self {
+        Self { ctx, stmts: RefCell::new(Vec::new()) }
+    }
+}
+
+impl<'a> Transformer for UnnestExprTransformer<'a> {
+    fn visit_stmt(&self, _stmt: &mut Stmt) {
+        // Do not recurse into nested statements
+    }
+
+    fn visit_expr(&self, expr: &mut Expr) {
+        walk_expr(self, expr);
+        if !is_simple(expr) {
+            let tmp = self.ctx.namer.fresh("_dp_tmp");
+            let value = expr.clone();
+            let assign = crate::py_stmt!(
+                "\n{tmp:id} = {expr:expr}\n",
+                tmp = tmp.as_str(),
+                expr = value,
+            );
+            self.stmts.borrow_mut().push(assign);
+            *expr = crate::py_expr!(
+                "\n{tmp:id}\n",
+                tmp = tmp.as_str(),
+            );
+        }
+    }
+}
+
+pub fn unnest_expr(ctx: &Context, mut expr: Expr) -> (Expr, Vec<Stmt>) {
+    let transformer = UnnestExprTransformer::new(ctx);
+    transformer.visit_expr(&mut expr);
+    let stmts = transformer.stmts.take();
+    (expr, stmts)
+}
+
+pub fn unnest_exprs(ctx: &Context, exprs: Vec<Expr>) -> (Vec<Expr>, Vec<Stmt>) {
+    let mut out = Vec::new();
+    let mut stmts = Vec::new();
+    for expr in exprs {
+        let (expr, mut s) = unnest_expr(ctx, expr);
+        out.push(expr);
+        stmts.append(&mut s);
+    }
+    (out, stmts)
+}


### PR DESCRIPTION
## Summary
- add `UnnestTransformer` to hoist complex expressions from statements into temporary assignments
- expose the new unnest module through the transform module tree
- test statement unnesting on a nested binary expression

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c7638aafbc8324b8d75672b8019d39