### PR TITLE
Unify transform naming around Context::fresh

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod template;
 mod test_util;
 mod transform;
 
-use transform::{expr::ExprRewriter, truthy::TruthyRewriter, Options};
+use transform::{context::Context, expr::ExprRewriter, truthy::TruthyRewriter, Options};
 
 fn should_skip(source: &str) -> bool {
     source
@@ -31,7 +31,8 @@ fn should_skip(source: &str) -> bool {
 fn apply_transforms(module: &mut ModModule, options: Options) {
     // Lower `for` loops, expand generators and lambdas, and replace
     // `__dp__.<name>` calls with `getattr` in a single pass.
-    let expr_transformer = ExprRewriter::new(options);
+    let ctx = Context::new(options);
+    let expr_transformer = ExprRewriter::new(&ctx);
     expr_transformer.rewrite_body(&mut module.body);
 
     // Collapse `py_stmt!` templates after all rewrites.

--- a/src/transform/context.rs
+++ b/src/transform/context.rs
@@ -1,0 +1,39 @@
+use std::cell::Cell;
+
+use super::Options;
+
+pub struct Namer {
+    counter: Cell<usize>,
+}
+
+impl Namer {
+    pub fn new() -> Self {
+        Self {
+            counter: Cell::new(0),
+        }
+    }
+
+    pub fn fresh(&self, name: &str) -> String {
+        let id = self.counter.get() + 1;
+        self.counter.set(id);
+        format!("_dp_{name}_{id}")
+    }
+}
+
+pub struct Context {
+    pub namer: Namer,
+    pub options: Options,
+}
+
+impl Context {
+    pub fn new(options: Options) -> Self {
+        Self {
+            namer: Namer::new(),
+            options,
+        }
+    }
+
+    pub fn fresh(&self, name: &str) -> String {
+        self.namer.fresh(name)
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod context;
 pub(crate) mod expr;
 pub(crate) mod rewrite_assert;
 pub(crate) mod rewrite_class_def;

--- a/src/transform/rewrite_for_loop.rs
+++ b/src/transform/rewrite_for_loop.rs
@@ -1,5 +1,4 @@
-use std::cell::Cell;
-
+use super::context::Context;
 use ruff_python_ast::{self as ast, Stmt};
 
 use crate::{py_expr, py_stmt};
@@ -13,11 +12,9 @@ pub fn rewrite(
         is_async,
         ..
     }: ast::StmtFor,
-    iter_count: &Cell<usize>,
+    ctx: &Context,
 ) -> Stmt {
-    let id = iter_count.get() + 1;
-    iter_count.set(id);
-    let iter_name = format!("_dp_iter_{}", id);
+    let iter_name = ctx.fresh("iter");
 
     let (iter_fn, next_fn, stop_exc, await_) = if is_async {
         (
@@ -78,8 +75,8 @@ while True:
     try:
         a = __dp__.next(_dp_iter_1)
     except:
-        _dp_exc_1 = __dp__.current_exception()
-        if __dp__.isinstance(_dp_exc_1, StopIteration):
+        _dp_exc_2 = __dp__.current_exception()
+        if __dp__.isinstance(_dp_exc_2, StopIteration):
             c()
             break
         else:
@@ -102,8 +99,8 @@ while True:
     try:
         a = __dp__.next(_dp_iter_1)
     except:
-        _dp_exc_1 = __dp__.current_exception()
-        if __dp__.isinstance(_dp_exc_1, StopIteration):
+        _dp_exc_2 = __dp__.current_exception()
+        if __dp__.isinstance(_dp_exc_2, StopIteration):
             break
         else:
             raise
@@ -130,8 +127,8 @@ async def f():
         try:
             a = await __dp__.anext(_dp_iter_1)
         except:
-            _dp_exc_1 = __dp__.current_exception()
-            if __dp__.isinstance(_dp_exc_1, StopAsyncIteration):
+            _dp_exc_2 = __dp__.current_exception()
+            if __dp__.isinstance(_dp_exc_2, StopAsyncIteration):
                 c()
                 break
             else:

--- a/src/transform/rewrite_import.rs
+++ b/src/transform/rewrite_import.rs
@@ -70,7 +70,7 @@ pub fn rewrite_from(
 #[cfg(test)]
 mod tests {
     use crate::test_util::assert_transform_eq;
-    use crate::transform::{expr::ExprRewriter, ImportStarHandling, Options};
+    use crate::transform::{context::Context, expr::ExprRewriter, ImportStarHandling, Options};
     use ruff_python_parser::parse_module;
 
     #[test]
@@ -126,7 +126,8 @@ x = 1
 
     fn rewrite_source(source: &str, options: Options) -> String {
         let mut module = parse_module(source).expect("parse error").into_syntax();
-        let expr_transformer = ExprRewriter::new(options);
+        let ctx = Context::new(options);
+        let expr_transformer = ExprRewriter::new(&ctx);
         expr_transformer.rewrite_body(&mut module.body);
         crate::template::flatten(&mut module.body);
         crate::ruff_ast_to_string(&module.body)

--- a/src/transform/rewrite_try_except.rs
+++ b/src/transform/rewrite_try_except.rs
@@ -1,10 +1,9 @@
-use std::cell::Cell;
-
+use super::context::Context;
 use ruff_python_ast::{self as ast, Expr, Stmt};
 
 use crate::py_stmt;
 
-pub fn rewrite(stmt: ast::StmtTry, count: &Cell<usize>) -> Stmt {
+pub fn rewrite(stmt: ast::StmtTry, ctx: &Context) -> Stmt {
     if !has_non_default_handler(&stmt) {
         return Stmt::Try(stmt);
     }
@@ -17,9 +16,7 @@ pub fn rewrite(stmt: ast::StmtTry, count: &Cell<usize>) -> Stmt {
         is_star: _,
         ..
     } = stmt;
-    let id = count.get() + 1;
-    count.set(id);
-    let exc_name = format!("_dp_exc_{}", id);
+    let exc_name = ctx.fresh("exc");
 
     let exc_assign = py_stmt!(
         "{exc:id} = __dp__.current_exception()",

--- a/src/transform/unnest.rs
+++ b/src/transform/unnest.rs
@@ -1,38 +1,14 @@
+use super::context::Context;
 use ruff_python_ast::visitor::transformer::{walk_stmt, Transformer};
 use ruff_python_ast::Stmt;
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 
 use ruff_python_ast::visitor::transformer::walk_expr;
 use ruff_python_ast::Expr;
 
 use crate::template::is_simple;
-use crate::transform::Options;
-
 use crate::{py_expr, py_stmt};
-
-pub struct Namer {
-    pub counter: Cell<usize>,
-}
-
-impl Namer {
-    pub fn new() -> Self {
-        Self {
-            counter: Cell::new(0),
-        }
-    }
-
-    pub fn fresh(&self, prefix: &str) -> String {
-        let id = self.counter.get();
-        self.counter.set(id + 1);
-        format!("{prefix}_{id}")
-    }
-}
-
-pub struct Context {
-    pub namer: Namer,
-    pub options: Options,
-}
 
 pub struct UnnestExprTransformer<'a> {
     pub ctx: &'a Context,
@@ -56,7 +32,7 @@ impl<'a> Transformer for UnnestExprTransformer<'a> {
     fn visit_expr(&self, expr: &mut Expr) {
         walk_expr(self, expr);
         if !is_simple(expr) {
-            let tmp = self.ctx.namer.fresh("_dp_tmp");
+            let tmp = self.ctx.fresh("tmp");
             let value = expr.clone();
             let assign = py_stmt!(
                 "\n{tmp:id} = {expr:expr}\n",
@@ -103,7 +79,6 @@ pub fn unnest_stmts(ctx: &Context, mut stmts: Vec<Stmt>) -> Vec<Stmt> {
 #[cfg(test)]
 mod tests {
     use super::super::Options;
-    use super::Namer;
     use super::*;
     use crate::test_util::assert_ast_eq;
     use ruff_python_parser::parse_module;
@@ -114,16 +89,13 @@ mod tests {
 a = (1 + 2) + (3 + 4)
 "#;
         let module = parse_module(input).unwrap().into_syntax();
-        let ctx = Context {
-            namer: Namer::new(),
-            options: Options::for_test(),
-        };
+        let ctx = Context::new(Options::for_test());
         let body = unnest_stmts(&ctx, module.body);
         let expected = r#"
-_dp_tmp_0 = 1 + 2
-_dp_tmp_1 = 3 + 4
-_dp_tmp_2 = _dp_tmp_0 + _dp_tmp_1
-a = _dp_tmp_2
+_dp_tmp_1 = 1 + 2
+_dp_tmp_2 = 3 + 4
+_dp_tmp_3 = _dp_tmp_1 + _dp_tmp_2
+a = _dp_tmp_3
 "#;
         let expected = parse_module(expected).unwrap().into_syntax();
         assert_ast_eq(&body, &expected.body);


### PR DESCRIPTION
## Summary
- replace the transform context's individual counters with a shared `fresh` helper that always prefixes names with `_dp_`
- update expression, try/except, for-loop, with-statement, decorator, match-case, and unnest rewrites to allocate identifiers through `ctx.fresh`
- refresh the affected rewrite tests to assert the new sequential `_dp_` names

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c848ea8a208324b4299b329ffc85eb