### PR TITLE
Prevent LambdaGeneratorLowerer from recursing into nested statements

### DIFF
--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -332,6 +332,16 @@ impl<'a> Transformer for ExprRewriter<'a> {
     }
 
     fn visit_stmt(&self, stmt: &mut Stmt) {
+        let lowerer = rewrite_expr_to_stmt::LambdaGeneratorLowerer::new(self.ctx);
+        lowerer.rewrite(stmt);
+        let mut lowered_functions = lowerer.into_statements();
+        if !lowered_functions.is_empty() {
+            lowered_functions.push(stmt.clone());
+            *stmt = single_stmt(lowered_functions);
+            self.visit_stmt(stmt);
+            return;
+        }
+
         match rewrite_expr_to_stmt::expr_to_stmt(self.ctx, stmt.clone()) {
             rewrite_expr_to_stmt::Modified::Yes(new_stmt) => {
                 *stmt = new_stmt;


### PR DESCRIPTION
## Summary
- expose `LambdaGeneratorLowerer` with a new `rewrite` helper that only walks the current statement
- ensure the lowerer never recurses into sub-statements by making `visit_stmt` a no-op
- invoke the new rewrite helper at the start of `ExprRewriter::visit_stmt` so lowered lambdas are wrapped with their generated functions

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c9c55d683883248fa32a164fe4ab57