### PR TITLE
Handle comparisons via unnesting

### DIFF
--- a/src/transform/rewrite_match_case.rs
+++ b/src/transform/rewrite_match_case.rs
@@ -268,13 +268,18 @@ match x:
 "#;
         let expected = r#"
 _dp_match_1 = x
-if __dp__.eq(_dp_match_1, 1):
-    a()
+_dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
+if _dp_tmp_2:
+    _dp_tmp_3 = a()
+    _dp_tmp_3
 else:
-    if __dp__.eq(_dp_match_1, 2):
-        b()
+    _dp_tmp_4 = __dp__.eq(_dp_match_1, 2)
+    if _dp_tmp_4:
+        _dp_tmp_5 = b()
+        _dp_tmp_5
     else:
-        c()
+        _dp_tmp_6 = c()
+        _dp_tmp_6
 "#;
         assert_transform_eq(input, expected);
     }
@@ -341,10 +346,13 @@ match x:
 "#;
         let expected = r#"
 _dp_match_1 = x
-if __dp__.is_(_dp_match_1, None):
-    a()
+_dp_tmp_2 = __dp__.is_(_dp_match_1, None)
+if _dp_tmp_2:
+    _dp_tmp_3 = a()
+    _dp_tmp_3
 else:
-    b()
+    _dp_tmp_4 = b()
+    _dp_tmp_4
 "#;
         assert_transform_eq(input, expected);
     }
@@ -360,11 +368,14 @@ match x:
 "#;
         let expected = r#"
 _dp_match_1 = x
-if __dp__.eq(_dp_match_1, 1):
+_dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
+if _dp_tmp_2:
     y = _dp_match_1
-    a()
+    _dp_tmp_3 = a()
+    _dp_tmp_3
 else:
-    b()
+    _dp_tmp_4 = b()
+    _dp_tmp_4
 "#;
         assert_transform_eq(input, expected);
     }
@@ -380,11 +391,14 @@ match x:
 "#;
         let expected = r#"
 _dp_match_1 = x
-if __dp__.eq(_dp_match_1, 1):
-    a()
+_dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
+if _dp_tmp_2:
+    _dp_tmp_3 = a()
+    _dp_tmp_3
 else:
     y = _dp_match_1
-    b()
+    _dp_tmp_4 = b()
+    _dp_tmp_4
 "#;
         assert_transform_eq(input, expected);
     }


### PR DESCRIPTION
## Summary
- add `expr_compare_to_stmts` to lower comparisons into statements that short-circuit chained comparisons
- update the unnest transformer to hoist comparison expressions and refresh related transformation tests
- adjust comprehension and match-case expectations to account for comparison temporaries

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ca2e0f0b7083249931fcb195e4dc60