### PR TITLE
Unnest if expressions

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -107,11 +107,6 @@ def import_(name, spec, fromlist=None, level=0):
     return builtins.__import__(name, globals_dict, {}, fromlist, level)
 
 
-def if_expr(cond, body, orelse):
-    cond_val = truth(cond)
-    return body() if cond_val else orelse()
-
-
 # Tags as ints for yield from state machine
 RUNNING = 0
 RETURN = 1


### PR DESCRIPTION
## Summary
- unnest ternary expressions via the UnnestExprTransformer into explicit if statements rather than calling `__dp__.if_expr`
- ensure complex expression detection considers ternary expressions so the unnest pass runs
- update the if-expression rewrite tests to reflect the hoisted temporaries and explicit branches
- remove the now-unused `__dp__.if_expr` helper

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ca3195adc48324abf37501d7c4d6a0