### PR TITLE
Handle starred targets in rewrites

### DIFF
--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -448,7 +448,8 @@ impl<'a> Transformer for ExprRewriter<'a> {
 
         let current = stmt.clone();
         *stmt = match current {
-            Stmt::With(with) => rewrite_with::rewrite(with.clone(), self.ctx),
+            Stmt::With(with) => rewrite_with::rewrite(with, self.ctx, self),
+            Stmt::For(for_stmt) => rewrite_for_loop::rewrite(for_stmt, self.ctx, self),
             Stmt::Assert(assert) => rewrite_assert::rewrite(assert.clone()),
             Stmt::ClassDef(class_def) => {
                 let decorated = !class_def.decorator_list.is_empty();
@@ -469,7 +470,6 @@ impl<'a> Transformer for ExprRewriter<'a> {
                     base_stmt
                 }
             }
-            Stmt::For(for_stmt) => rewrite_for_loop::rewrite(for_stmt.clone(), self.ctx),
             Stmt::Try(try_stmt) => rewrite_try_except::rewrite(try_stmt.clone(), self.ctx),
             Stmt::Match(match_stmt) => rewrite_match_case::rewrite(match_stmt.clone(), self.ctx),
             Stmt::Import(import) => rewrite_import::rewrite(import.clone()),


### PR DESCRIPTION
## Summary
- ensure rewritten `with` and `for` statements invoke the transformer internally so starred targets are fully desugared
- add regression tests covering starred targets in `with` and `for` rewrites
- inline the `with` and `for` rewrites into the main statement match block to avoid redundant pattern checks

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caeb5180888324a8540bc485b740d3