### PR TITLE
Restore borrow-based owned walker clones

### DIFF
--- a/src/owned_transform.rs
+++ b/src/owned_transform.rs
@@ -1,81 +1,140 @@
+use std::borrow::Borrow;
+
 use ruff_python_ast::{self as ast, Expr, Stmt};
+
+pub trait OwnNode<T>: Borrow<T> + From<T> + Clone {}
+
+impl<T> OwnNode<T> for T where T: From<T> + Borrow<T> + Clone {}
+
+impl<T> OwnNode<T> for Box<T> where Box<T>: Borrow<T> + From<T> + Clone {}
 
 /// A trait for transforming owned AST nodes.
 pub trait OwnedTransform {
     /// Transform an [`Expr`], returning the transformed expression.
-    fn visit_expr_owned(&self, expr: Expr) -> Expr {
+    fn visit_expr_owned<N>(&self, expr: N) -> N
+    where
+        N: OwnNode<Expr>,
+    {
         walk_expr_owned(self, expr)
     }
 
     /// Transform a [`Stmt`], returning the transformed statement.
-    fn visit_stmt_owned(&self, stmt: Stmt) -> Stmt {
+    fn visit_stmt_owned<N>(&self, stmt: N) -> N
+    where
+        N: OwnNode<Stmt>,
+    {
         walk_stmt_owned(self, stmt)
     }
 
-    fn visit_arguments_owned(&self, arguments: ast::Arguments) -> ast::Arguments {
+    fn visit_arguments_owned<N>(&self, arguments: N) -> N
+    where
+        N: OwnNode<ast::Arguments>,
+    {
         walk_arguments_owned(self, arguments)
     }
 
-    fn visit_keyword_owned(&self, keyword: ast::Keyword) -> ast::Keyword {
+    fn visit_keyword_owned<N>(&self, keyword: N) -> N
+    where
+        N: OwnNode<ast::Keyword>,
+    {
         walk_keyword_owned(self, keyword)
     }
 
-    fn visit_parameters_owned(&self, parameters: ast::Parameters) -> ast::Parameters {
+    fn visit_parameters_owned<N>(&self, parameters: N) -> N
+    where
+        N: OwnNode<ast::Parameters>,
+    {
         walk_parameters_owned(self, parameters)
     }
 
-    fn visit_parameter_with_default_owned(
-        &self,
-        param: ast::ParameterWithDefault,
-    ) -> ast::ParameterWithDefault {
+    fn visit_parameter_with_default_owned<N>(&self, param: N) -> N
+    where
+        N: OwnNode<ast::ParameterWithDefault>,
+    {
         walk_parameter_with_default_owned(self, param)
     }
 
-    fn visit_parameter_owned(&self, parameter: ast::Parameter) -> ast::Parameter {
+    fn visit_parameter_owned<N>(&self, parameter: N) -> N
+    where
+        N: OwnNode<ast::Parameter>,
+    {
         walk_parameter_owned(self, parameter)
     }
 
-    fn visit_comprehension_owned(&self, comprehension: ast::Comprehension) -> ast::Comprehension {
+    fn visit_comprehension_owned<N>(&self, comprehension: N) -> N
+    where
+        N: OwnNode<ast::Comprehension>,
+    {
         walk_comprehension_owned(self, comprehension)
     }
 
-    fn visit_with_item_owned(&self, with_item: ast::WithItem) -> ast::WithItem {
+    fn visit_with_item_owned<N>(&self, with_item: N) -> N
+    where
+        N: OwnNode<ast::WithItem>,
+    {
         walk_with_item_owned(self, with_item)
     }
 
-    fn visit_type_params_owned(&self, type_params: ast::TypeParams) -> ast::TypeParams {
+    fn visit_type_params_owned<N>(&self, type_params: N) -> N
+    where
+        N: OwnNode<ast::TypeParams>,
+    {
         walk_type_params_owned(self, type_params)
     }
 
-    fn visit_type_param_owned(&self, type_param: ast::TypeParam) -> ast::TypeParam {
+    fn visit_type_param_owned<N>(&self, type_param: N) -> N
+    where
+        N: OwnNode<ast::TypeParam>,
+    {
         walk_type_param_owned(self, type_param)
     }
 
-    fn visit_match_case_owned(&self, case: ast::MatchCase) -> ast::MatchCase {
+    fn visit_match_case_owned<N>(&self, case: N) -> N
+    where
+        N: OwnNode<ast::MatchCase>,
+    {
         walk_match_case_owned(self, case)
     }
 
-    fn visit_pattern_owned(&self, pattern: ast::Pattern) -> ast::Pattern {
+    fn visit_pattern_owned<N>(&self, pattern: N) -> N
+    where
+        N: OwnNode<ast::Pattern>,
+    {
         walk_pattern_owned(self, pattern)
     }
 
-    fn visit_pattern_arguments_owned(&self, args: ast::PatternArguments) -> ast::PatternArguments {
+    fn visit_pattern_arguments_owned<N>(&self, args: N) -> N
+    where
+        N: OwnNode<ast::PatternArguments>,
+    {
         walk_pattern_arguments_owned(self, args)
     }
 
-    fn visit_pattern_keyword_owned(&self, keyword: ast::PatternKeyword) -> ast::PatternKeyword {
+    fn visit_pattern_keyword_owned<N>(&self, keyword: N) -> N
+    where
+        N: OwnNode<ast::PatternKeyword>,
+    {
         walk_pattern_keyword_owned(self, keyword)
     }
 
-    fn visit_decorator_owned(&self, decorator: ast::Decorator) -> ast::Decorator {
+    fn visit_decorator_owned<N>(&self, decorator: N) -> N
+    where
+        N: OwnNode<ast::Decorator>,
+    {
         walk_decorator_owned(self, decorator)
     }
 
-    fn visit_except_handler_owned(&self, handler: ast::ExceptHandler) -> ast::ExceptHandler {
+    fn visit_except_handler_owned<N>(&self, handler: N) -> N
+    where
+        N: OwnNode<ast::ExceptHandler>,
+    {
         walk_except_handler_owned(self, handler)
     }
 
-    fn visit_elif_else_clause_owned(&self, clause: ast::ElifElseClause) -> ast::ElifElseClause {
+    fn visit_elif_else_clause_owned<N>(&self, clause: N) -> N
+    where
+        N: OwnNode<ast::ElifElseClause>,
+    {
         walk_elif_else_clause_owned(self, clause)
     }
 
@@ -87,23 +146,29 @@ pub trait OwnedTransform {
         walk_t_string_owned(self, t_string)
     }
 
-    fn visit_interpolated_string_element_owned(
-        &self,
-        element: ast::InterpolatedStringElement,
-    ) -> ast::InterpolatedStringElement {
+    fn visit_interpolated_string_element_owned<N>(&self, element: N) -> N
+    where
+        N: OwnNode<ast::InterpolatedStringElement>,
+    {
         walk_interpolated_string_element_owned(self, element)
     }
 
-    fn visit_interpolated_string_format_spec_owned(
-        &self,
-        spec: ast::InterpolatedStringFormatSpec,
-    ) -> ast::InterpolatedStringFormatSpec {
+    fn visit_interpolated_string_format_spec_owned<N>(&self, spec: N) -> N
+    where
+        N: OwnNode<ast::InterpolatedStringFormatSpec>,
+    {
         walk_interpolated_string_format_spec_owned(self, spec)
     }
 }
 
-pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) -> Expr {
-    match expr {
+pub fn walk_expr_owned<T, N>(transformer: &T, expr: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<Expr>,
+{
+    let expr = expr.borrow().clone();
+
+    let expr = match expr {
         Expr::BoolOp(mut node) => {
             node.values = node
                 .values
@@ -113,30 +178,30 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
             Expr::BoolOp(node)
         }
         Expr::Named(mut node) => {
-            node.target = Box::new(transformer.visit_expr_owned(*node.target));
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.target = transformer.visit_expr_owned(node.target);
+            node.value = transformer.visit_expr_owned(node.value);
             Expr::Named(node)
         }
         Expr::BinOp(mut node) => {
-            node.left = Box::new(transformer.visit_expr_owned(*node.left));
-            node.right = Box::new(transformer.visit_expr_owned(*node.right));
+            node.left = transformer.visit_expr_owned(node.left);
+            node.right = transformer.visit_expr_owned(node.right);
             Expr::BinOp(node)
         }
         Expr::UnaryOp(mut node) => {
-            node.operand = Box::new(transformer.visit_expr_owned(*node.operand));
+            node.operand = transformer.visit_expr_owned(node.operand);
             Expr::UnaryOp(node)
         }
         Expr::Lambda(mut node) => {
             node.parameters = node
                 .parameters
-                .map(|parameters| Box::new(transformer.visit_parameters_owned(*parameters)));
-            node.body = Box::new(transformer.visit_expr_owned(*node.body));
+                .map(|parameters| transformer.visit_parameters_owned(parameters));
+            node.body = transformer.visit_expr_owned(node.body);
             Expr::Lambda(node)
         }
         Expr::If(mut node) => {
-            node.test = Box::new(transformer.visit_expr_owned(*node.test));
-            node.body = Box::new(transformer.visit_expr_owned(*node.body));
-            node.orelse = Box::new(transformer.visit_expr_owned(*node.orelse));
+            node.test = transformer.visit_expr_owned(node.test);
+            node.body = transformer.visit_expr_owned(node.body);
+            node.orelse = transformer.visit_expr_owned(node.orelse);
             Expr::If(node)
         }
         Expr::Dict(mut node) => {
@@ -165,7 +230,7 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
                 .into_iter()
                 .map(|comp| transformer.visit_comprehension_owned(comp))
                 .collect();
-            node.elt = Box::new(transformer.visit_expr_owned(*node.elt));
+            node.elt = transformer.visit_expr_owned(node.elt);
             Expr::ListComp(node)
         }
         Expr::SetComp(mut node) => {
@@ -174,7 +239,7 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
                 .into_iter()
                 .map(|comp| transformer.visit_comprehension_owned(comp))
                 .collect();
-            node.elt = Box::new(transformer.visit_expr_owned(*node.elt));
+            node.elt = transformer.visit_expr_owned(node.elt);
             Expr::SetComp(node)
         }
         Expr::DictComp(mut node) => {
@@ -183,8 +248,8 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
                 .into_iter()
                 .map(|comp| transformer.visit_comprehension_owned(comp))
                 .collect();
-            node.key = Box::new(transformer.visit_expr_owned(*node.key));
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.key = transformer.visit_expr_owned(node.key);
+            node.value = transformer.visit_expr_owned(node.value);
             Expr::DictComp(node)
         }
         Expr::Generator(mut node) => {
@@ -193,25 +258,23 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
                 .into_iter()
                 .map(|comp| transformer.visit_comprehension_owned(comp))
                 .collect();
-            node.elt = Box::new(transformer.visit_expr_owned(*node.elt));
+            node.elt = transformer.visit_expr_owned(node.elt);
             Expr::Generator(node)
         }
         Expr::Await(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             Expr::Await(node)
         }
         Expr::Yield(mut node) => {
-            node.value = node
-                .value
-                .map(|value| Box::new(transformer.visit_expr_owned(*value)));
+            node.value = node.value.map(|value| transformer.visit_expr_owned(value));
             Expr::Yield(node)
         }
         Expr::YieldFrom(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             Expr::YieldFrom(node)
         }
         Expr::Compare(mut node) => {
-            node.left = Box::new(transformer.visit_expr_owned(*node.left));
+            node.left = transformer.visit_expr_owned(node.left);
             node.comparators = node
                 .comparators
                 .into_vec()
@@ -222,7 +285,7 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
             Expr::Compare(node)
         }
         Expr::Call(mut node) => {
-            node.func = Box::new(transformer.visit_expr_owned(*node.func));
+            node.func = transformer.visit_expr_owned(node.func);
             node.arguments = transformer.visit_arguments_owned(node.arguments);
             Expr::Call(node)
         }
@@ -247,16 +310,16 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
         Expr::NoneLiteral(node) => Expr::NoneLiteral(node),
         Expr::EllipsisLiteral(node) => Expr::EllipsisLiteral(node),
         Expr::Attribute(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             Expr::Attribute(node)
         }
         Expr::Subscript(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
-            node.slice = Box::new(transformer.visit_expr_owned(*node.slice));
+            node.value = transformer.visit_expr_owned(node.value);
+            node.slice = transformer.visit_expr_owned(node.slice);
             Expr::Subscript(node)
         }
         Expr::Starred(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             Expr::Starred(node)
         }
         Expr::Name(node) => Expr::Name(node),
@@ -277,23 +340,25 @@ pub fn walk_expr_owned<T: OwnedTransform + ?Sized>(transformer: &T, expr: Expr) 
             Expr::Tuple(node)
         }
         Expr::Slice(mut node) => {
-            node.lower = node
-                .lower
-                .map(|expr| Box::new(transformer.visit_expr_owned(*expr)));
-            node.upper = node
-                .upper
-                .map(|expr| Box::new(transformer.visit_expr_owned(*expr)));
-            node.step = node
-                .step
-                .map(|expr| Box::new(transformer.visit_expr_owned(*expr)));
+            node.lower = node.lower.map(|expr| transformer.visit_expr_owned(expr));
+            node.upper = node.upper.map(|expr| transformer.visit_expr_owned(expr));
+            node.step = node.step.map(|expr| transformer.visit_expr_owned(expr));
             Expr::Slice(node)
         }
         Expr::IpyEscapeCommand(node) => Expr::IpyEscapeCommand(node),
-    }
+    };
+
+    N::from(expr)
 }
 
-pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) -> Stmt {
-    match stmt {
+pub fn walk_stmt_owned<T, N>(transformer: &T, stmt: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<Stmt>,
+{
+    let stmt = stmt.borrow().clone();
+
+    let stmt = match stmt {
         Stmt::FunctionDef(mut node) => {
             node.decorator_list = node
                 .decorator_list
@@ -302,11 +367,11 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
                 .collect();
             node.type_params = node
                 .type_params
-                .map(|type_params| Box::new(transformer.visit_type_params_owned(*type_params)));
-            node.parameters = Box::new(transformer.visit_parameters_owned(*node.parameters));
+                .map(|type_params| transformer.visit_type_params_owned(type_params));
+            node.parameters = transformer.visit_parameters_owned(node.parameters);
             node.returns = node
                 .returns
-                .map(|returns| Box::new(transformer.visit_expr_owned(*returns)));
+                .map(|returns| transformer.visit_expr_owned(returns));
             node.body = node
                 .body
                 .into_iter()
@@ -322,10 +387,10 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
                 .collect();
             node.type_params = node
                 .type_params
-                .map(|type_params| Box::new(transformer.visit_type_params_owned(*type_params)));
+                .map(|type_params| transformer.visit_type_params_owned(type_params));
             node.arguments = node
                 .arguments
-                .map(|arguments| Box::new(transformer.visit_arguments_owned(*arguments)));
+                .map(|arguments| transformer.visit_arguments_owned(arguments));
             node.body = node
                 .body
                 .into_iter()
@@ -334,9 +399,7 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::ClassDef(node)
         }
         Stmt::Return(mut node) => {
-            node.value = node
-                .value
-                .map(|value| Box::new(transformer.visit_expr_owned(*value)));
+            node.value = node.value.map(|value| transformer.visit_expr_owned(value));
             Stmt::Return(node)
         }
         Stmt::Delete(mut node) => {
@@ -348,15 +411,15 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::Delete(node)
         }
         Stmt::TypeAlias(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             node.type_params = node
                 .type_params
-                .map(|type_params| Box::new(transformer.visit_type_params_owned(*type_params)));
-            node.name = Box::new(transformer.visit_expr_owned(*node.name));
+                .map(|type_params| transformer.visit_type_params_owned(type_params));
+            node.name = transformer.visit_expr_owned(node.name);
             Stmt::TypeAlias(node)
         }
         Stmt::Assign(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             node.targets = node
                 .targets
                 .into_iter()
@@ -365,21 +428,19 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::Assign(node)
         }
         Stmt::AugAssign(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
-            node.target = Box::new(transformer.visit_expr_owned(*node.target));
+            node.value = transformer.visit_expr_owned(node.value);
+            node.target = transformer.visit_expr_owned(node.target);
             Stmt::AugAssign(node)
         }
         Stmt::AnnAssign(mut node) => {
-            node.value = node
-                .value
-                .map(|value| Box::new(transformer.visit_expr_owned(*value)));
-            node.annotation = Box::new(transformer.visit_expr_owned(*node.annotation));
-            node.target = Box::new(transformer.visit_expr_owned(*node.target));
+            node.value = node.value.map(|value| transformer.visit_expr_owned(value));
+            node.annotation = transformer.visit_expr_owned(node.annotation);
+            node.target = transformer.visit_expr_owned(node.target);
             Stmt::AnnAssign(node)
         }
         Stmt::For(mut node) => {
-            node.iter = Box::new(transformer.visit_expr_owned(*node.iter));
-            node.target = Box::new(transformer.visit_expr_owned(*node.target));
+            node.iter = transformer.visit_expr_owned(node.iter);
+            node.target = transformer.visit_expr_owned(node.target);
             node.body = node
                 .body
                 .into_iter()
@@ -393,7 +454,7 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::For(node)
         }
         Stmt::While(mut node) => {
-            node.test = Box::new(transformer.visit_expr_owned(*node.test));
+            node.test = transformer.visit_expr_owned(node.test);
             node.body = node
                 .body
                 .into_iter()
@@ -407,7 +468,7 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::While(node)
         }
         Stmt::If(mut node) => {
-            node.test = Box::new(transformer.visit_expr_owned(*node.test));
+            node.test = transformer.visit_expr_owned(node.test);
             node.body = node
                 .body
                 .into_iter()
@@ -434,7 +495,7 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::With(node)
         }
         Stmt::Match(mut node) => {
-            node.subject = Box::new(transformer.visit_expr_owned(*node.subject));
+            node.subject = transformer.visit_expr_owned(node.subject);
             node.cases = node
                 .cases
                 .into_iter()
@@ -443,12 +504,8 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::Match(node)
         }
         Stmt::Raise(mut node) => {
-            node.exc = node
-                .exc
-                .map(|exc| Box::new(transformer.visit_expr_owned(*exc)));
-            node.cause = node
-                .cause
-                .map(|cause| Box::new(transformer.visit_expr_owned(*cause)));
+            node.exc = node.exc.map(|exc| transformer.visit_expr_owned(exc));
+            node.cause = node.cause.map(|cause| transformer.visit_expr_owned(cause));
             Stmt::Raise(node)
         }
         Stmt::Try(mut node) => {
@@ -475,10 +532,8 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
             Stmt::Try(node)
         }
         Stmt::Assert(mut node) => {
-            node.test = Box::new(transformer.visit_expr_owned(*node.test));
-            node.msg = node
-                .msg
-                .map(|msg| Box::new(transformer.visit_expr_owned(*msg)));
+            node.test = transformer.visit_expr_owned(node.test);
+            node.msg = node.msg.map(|msg| transformer.visit_expr_owned(msg));
             Stmt::Assert(node)
         }
         Stmt::Import(node) => Stmt::Import(node),
@@ -486,272 +541,205 @@ pub fn walk_stmt_owned<T: OwnedTransform + ?Sized>(transformer: &T, stmt: Stmt) 
         Stmt::Global(node) => Stmt::Global(node),
         Stmt::Nonlocal(node) => Stmt::Nonlocal(node),
         Stmt::Expr(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             Stmt::Expr(node)
         }
         Stmt::Pass(node) => Stmt::Pass(node),
         Stmt::Break(node) => Stmt::Break(node),
         Stmt::Continue(node) => Stmt::Continue(node),
         Stmt::IpyEscapeCommand(node) => Stmt::IpyEscapeCommand(node),
-    }
+    };
+
+    N::from(stmt)
 }
 
-pub fn walk_arguments_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    arguments: ast::Arguments,
-) -> ast::Arguments {
-    let ast::Arguments {
-        range,
-        node_index,
-        args,
-        keywords,
-    } = arguments;
-    let args = args
+pub fn walk_arguments_owned<T, N>(transformer: &T, arguments: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::Arguments>,
+{
+    let mut arguments = arguments.borrow().clone();
+    let args = arguments
+        .args
         .into_vec()
         .into_iter()
         .map(|expr| transformer.visit_expr_owned(expr))
         .collect::<Vec<_>>()
         .into_boxed_slice();
-    let keywords = keywords
+    let keywords = arguments
+        .keywords
         .into_vec()
         .into_iter()
         .map(|kw| transformer.visit_keyword_owned(kw))
         .collect::<Vec<_>>()
         .into_boxed_slice();
-    ast::Arguments {
-        range,
-        node_index,
-        args,
-        keywords,
-    }
+    arguments.args = args;
+    arguments.keywords = keywords;
+    N::from(arguments)
 }
 
-pub fn walk_keyword_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    keyword: ast::Keyword,
-) -> ast::Keyword {
-    let ast::Keyword {
-        range,
-        node_index,
-        arg,
-        value,
-    } = keyword;
-    let value = transformer.visit_expr_owned(value);
-    ast::Keyword {
-        range,
-        node_index,
-        arg,
-        value,
-    }
+pub fn walk_keyword_owned<T, N>(transformer: &T, keyword: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::Keyword>,
+{
+    let mut keyword = keyword.borrow().clone();
+    keyword.value = transformer.visit_expr_owned(keyword.value);
+    N::from(keyword)
 }
 
-pub fn walk_parameters_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    parameters: ast::Parameters,
-) -> ast::Parameters {
-    let ast::Parameters {
-        range,
-        node_index,
-        posonlyargs,
-        args,
-        vararg,
-        kwonlyargs,
-        kwarg,
-    } = parameters;
-    let posonlyargs = posonlyargs
+pub fn walk_parameters_owned<T, N>(transformer: &T, parameters: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::Parameters>,
+{
+    let mut parameters = parameters.borrow().clone();
+    parameters.posonlyargs = parameters
+        .posonlyargs
         .into_iter()
         .map(|p| transformer.visit_parameter_with_default_owned(p))
         .collect();
-    let args = args
+    parameters.args = parameters
+        .args
         .into_iter()
         .map(|p| transformer.visit_parameter_with_default_owned(p))
         .collect();
-    let vararg = vararg.map(|p| Box::new(transformer.visit_parameter_owned(*p)));
-    let kwonlyargs = kwonlyargs
+    parameters.vararg = parameters
+        .vararg
+        .map(|p| transformer.visit_parameter_owned(p));
+    parameters.kwonlyargs = parameters
+        .kwonlyargs
         .into_iter()
         .map(|p| transformer.visit_parameter_with_default_owned(p))
         .collect();
-    let kwarg = kwarg.map(|p| Box::new(transformer.visit_parameter_owned(*p)));
-    ast::Parameters {
-        range,
-        node_index,
-        posonlyargs,
-        args,
-        vararg,
-        kwonlyargs,
-        kwarg,
-    }
+    parameters.kwarg = parameters
+        .kwarg
+        .map(|p| transformer.visit_parameter_owned(p));
+    N::from(parameters)
 }
 
-pub fn walk_parameter_with_default_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    param: ast::ParameterWithDefault,
-) -> ast::ParameterWithDefault {
-    let ast::ParameterWithDefault {
-        range,
-        node_index,
-        parameter,
-        default,
-    } = param;
-    let parameter = transformer.visit_parameter_owned(parameter);
-    let default = default.map(|expr| Box::new(transformer.visit_expr_owned(*expr)));
-    ast::ParameterWithDefault {
-        range,
-        node_index,
-        parameter,
-        default,
-    }
+pub fn walk_parameter_with_default_owned<T, N>(transformer: &T, param: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::ParameterWithDefault>,
+{
+    let mut param = param.borrow().clone();
+    param.parameter = transformer.visit_parameter_owned(param.parameter);
+    param.default = param.default.map(|expr| transformer.visit_expr_owned(expr));
+    N::from(param)
 }
 
-pub fn walk_parameter_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    parameter: ast::Parameter,
-) -> ast::Parameter {
-    let ast::Parameter {
-        range,
-        node_index,
-        name,
-        annotation,
-    } = parameter;
-    let annotation = annotation.map(|expr| Box::new(transformer.visit_expr_owned(*expr)));
-    ast::Parameter {
-        range,
-        node_index,
-        name,
-        annotation,
-    }
+pub fn walk_parameter_owned<T, N>(transformer: &T, parameter: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::Parameter>,
+{
+    let mut parameter = parameter.borrow().clone();
+    parameter.annotation = parameter
+        .annotation
+        .map(|expr| transformer.visit_expr_owned(expr));
+    N::from(parameter)
 }
 
-pub fn walk_comprehension_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    comprehension: ast::Comprehension,
-) -> ast::Comprehension {
-    let ast::Comprehension {
-        range,
-        node_index,
-        target,
-        iter,
-        ifs,
-        is_async,
-    } = comprehension;
-    let target = transformer.visit_expr_owned(target);
-    let iter = transformer.visit_expr_owned(iter);
-    let ifs = ifs
+pub fn walk_comprehension_owned<T, N>(transformer: &T, comprehension: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::Comprehension>,
+{
+    let mut comprehension = comprehension.borrow().clone();
+    comprehension.target = transformer.visit_expr_owned(comprehension.target);
+    comprehension.iter = transformer.visit_expr_owned(comprehension.iter);
+    comprehension.ifs = comprehension
+        .ifs
         .into_iter()
         .map(|expr| transformer.visit_expr_owned(expr))
         .collect();
-    ast::Comprehension {
-        range,
-        node_index,
-        target,
-        iter,
-        ifs,
-        is_async,
-    }
+    N::from(comprehension)
 }
 
-pub fn walk_with_item_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    with_item: ast::WithItem,
-) -> ast::WithItem {
-    let ast::WithItem {
-        range,
-        node_index,
-        context_expr,
-        optional_vars,
-    } = with_item;
-    let context_expr = transformer.visit_expr_owned(context_expr);
-    let optional_vars = optional_vars.map(|expr| Box::new(transformer.visit_expr_owned(*expr)));
-    ast::WithItem {
-        range,
-        node_index,
-        context_expr,
-        optional_vars,
-    }
+pub fn walk_with_item_owned<T, N>(transformer: &T, with_item: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::WithItem>,
+{
+    let mut with_item = with_item.borrow().clone();
+    with_item.context_expr = transformer.visit_expr_owned(with_item.context_expr);
+    with_item.optional_vars = with_item
+        .optional_vars
+        .map(|expr| transformer.visit_expr_owned(expr));
+    N::from(with_item)
 }
 
-pub fn walk_type_params_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    type_params: ast::TypeParams,
-) -> ast::TypeParams {
-    let ast::TypeParams {
-        range,
-        node_index,
-        type_params,
-    } = type_params;
-    let type_params = type_params
+pub fn walk_type_params_owned<T, N>(transformer: &T, type_params: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::TypeParams>,
+{
+    let mut type_params = type_params.borrow().clone();
+    type_params.type_params = type_params
+        .type_params
         .into_iter()
         .map(|tp| transformer.visit_type_param_owned(tp))
         .collect();
-    ast::TypeParams {
-        range,
-        node_index,
-        type_params,
-    }
+    N::from(type_params)
 }
 
-pub fn walk_type_param_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    type_param: ast::TypeParam,
-) -> ast::TypeParam {
-    match type_param {
+pub fn walk_type_param_owned<T, N>(transformer: &T, type_param: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::TypeParam>,
+{
+    let type_param = type_param.borrow().clone();
+    let type_param = match type_param {
         ast::TypeParam::TypeVar(mut node) => {
-            node.bound = node
-                .bound
-                .map(|bound| Box::new(transformer.visit_expr_owned(*bound)));
+            node.bound = node.bound.map(|bound| transformer.visit_expr_owned(bound));
             node.default = node
                 .default
-                .map(|default| Box::new(transformer.visit_expr_owned(*default)));
+                .map(|default| transformer.visit_expr_owned(default));
             ast::TypeParam::TypeVar(node)
         }
         ast::TypeParam::TypeVarTuple(mut node) => {
             node.default = node
                 .default
-                .map(|default| Box::new(transformer.visit_expr_owned(*default)));
+                .map(|default| transformer.visit_expr_owned(default));
             ast::TypeParam::TypeVarTuple(node)
         }
         ast::TypeParam::ParamSpec(mut node) => {
             node.default = node
                 .default
-                .map(|default| Box::new(transformer.visit_expr_owned(*default)));
+                .map(|default| transformer.visit_expr_owned(default));
             ast::TypeParam::ParamSpec(node)
         }
-    }
+    };
+
+    N::from(type_param)
 }
 
-pub fn walk_match_case_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    case: ast::MatchCase,
-) -> ast::MatchCase {
-    let ast::MatchCase {
-        range,
-        node_index,
-        pattern,
-        guard,
-        body,
-    } = case;
-    let pattern = transformer.visit_pattern_owned(pattern);
-    let guard = guard.map(|expr| Box::new(transformer.visit_expr_owned(*expr)));
-    let body = body
+pub fn walk_match_case_owned<T, N>(transformer: &T, case: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::MatchCase>,
+{
+    let mut case = case.borrow().clone();
+    case.pattern = transformer.visit_pattern_owned(case.pattern);
+    case.guard = case.guard.map(|expr| transformer.visit_expr_owned(expr));
+    case.body = case
+        .body
         .into_iter()
         .map(|stmt| transformer.visit_stmt_owned(stmt))
         .collect();
-    ast::MatchCase {
-        range,
-        node_index,
-        pattern,
-        guard,
-        body,
-    }
+    N::from(case)
 }
 
-pub fn walk_pattern_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    pattern: ast::Pattern,
-) -> ast::Pattern {
-    match pattern {
+pub fn walk_pattern_owned<T, N>(transformer: &T, pattern: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::Pattern>,
+{
+    let pattern = pattern.borrow().clone();
+    let pattern = match pattern {
         ast::Pattern::MatchValue(mut node) => {
-            node.value = Box::new(transformer.visit_expr_owned(*node.value));
+            node.value = transformer.visit_expr_owned(node.value);
             ast::Pattern::MatchValue(node)
         }
         ast::Pattern::MatchSingleton(node) => ast::Pattern::MatchSingleton(node),
@@ -777,7 +765,7 @@ pub fn walk_pattern_owned<T: OwnedTransform + ?Sized>(
             ast::Pattern::MatchMapping(node)
         }
         ast::Pattern::MatchClass(mut node) => {
-            node.cls = Box::new(transformer.visit_expr_owned(*node.cls));
+            node.cls = transformer.visit_expr_owned(node.cls);
             node.arguments = transformer.visit_pattern_arguments_owned(node.arguments);
             ast::Pattern::MatchClass(node)
         }
@@ -785,7 +773,7 @@ pub fn walk_pattern_owned<T: OwnedTransform + ?Sized>(
         ast::Pattern::MatchAs(mut node) => {
             node.pattern = node
                 .pattern
-                .map(|pattern| Box::new(transformer.visit_pattern_owned(*pattern)));
+                .map(|pattern| transformer.visit_pattern_owned(pattern));
             ast::Pattern::MatchAs(node)
         }
         ast::Pattern::MatchOr(mut node) => {
@@ -796,80 +784,59 @@ pub fn walk_pattern_owned<T: OwnedTransform + ?Sized>(
                 .collect();
             ast::Pattern::MatchOr(node)
         }
-    }
+    };
+
+    N::from(pattern)
 }
 
-pub fn walk_pattern_arguments_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    args: ast::PatternArguments,
-) -> ast::PatternArguments {
-    let ast::PatternArguments {
-        range,
-        node_index,
-        patterns,
-        keywords,
-    } = args;
-    let patterns = patterns
+pub fn walk_pattern_arguments_owned<T, N>(transformer: &T, args: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::PatternArguments>,
+{
+    let mut args = args.borrow().clone();
+    args.patterns = args
+        .patterns
         .into_iter()
         .map(|p| transformer.visit_pattern_owned(p))
         .collect();
-    let keywords = keywords
+    args.keywords = args
+        .keywords
         .into_iter()
         .map(|k| transformer.visit_pattern_keyword_owned(k))
         .collect();
-    ast::PatternArguments {
-        range,
-        node_index,
-        patterns,
-        keywords,
-    }
+    N::from(args)
 }
 
-pub fn walk_pattern_keyword_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    keyword: ast::PatternKeyword,
-) -> ast::PatternKeyword {
-    let ast::PatternKeyword {
-        range,
-        node_index,
-        attr,
-        pattern,
-    } = keyword;
-    let pattern = transformer.visit_pattern_owned(pattern);
-    ast::PatternKeyword {
-        range,
-        node_index,
-        attr,
-        pattern,
-    }
+pub fn walk_pattern_keyword_owned<T, N>(transformer: &T, keyword: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::PatternKeyword>,
+{
+    let mut keyword = keyword.borrow().clone();
+    keyword.pattern = transformer.visit_pattern_owned(keyword.pattern);
+    N::from(keyword)
 }
 
-pub fn walk_decorator_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    decorator: ast::Decorator,
-) -> ast::Decorator {
-    let ast::Decorator {
-        range,
-        node_index,
-        expression,
-    } = decorator;
-    let expression = transformer.visit_expr_owned(expression);
-    ast::Decorator {
-        range,
-        node_index,
-        expression,
-    }
+pub fn walk_decorator_owned<T, N>(transformer: &T, decorator: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::Decorator>,
+{
+    let mut decorator = decorator.borrow().clone();
+    decorator.expression = transformer.visit_expr_owned(decorator.expression);
+    N::from(decorator)
 }
 
-pub fn walk_except_handler_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    handler: ast::ExceptHandler,
-) -> ast::ExceptHandler {
-    match handler {
+pub fn walk_except_handler_owned<T, N>(transformer: &T, handler: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::ExceptHandler>,
+{
+    let handler = handler.borrow().clone();
+    let handler = match handler {
         ast::ExceptHandler::ExceptHandler(mut node) => {
-            node.type_ = node
-                .type_
-                .map(|type_| Box::new(transformer.visit_expr_owned(*type_)));
+            node.type_ = node.type_.map(|type_| transformer.visit_expr_owned(type_));
             node.body = node
                 .body
                 .into_iter()
@@ -877,30 +844,24 @@ pub fn walk_except_handler_owned<T: OwnedTransform + ?Sized>(
                 .collect();
             ast::ExceptHandler::ExceptHandler(node)
         }
-    }
+    };
+
+    N::from(handler)
 }
 
-pub fn walk_elif_else_clause_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    clause: ast::ElifElseClause,
-) -> ast::ElifElseClause {
-    let ast::ElifElseClause {
-        range,
-        node_index,
-        test,
-        body,
-    } = clause;
-    let test = test.map(|expr| transformer.visit_expr_owned(expr));
-    let body = body
+pub fn walk_elif_else_clause_owned<T, N>(transformer: &T, clause: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::ElifElseClause>,
+{
+    let mut clause = clause.borrow().clone();
+    clause.test = clause.test.map(|expr| transformer.visit_expr_owned(expr));
+    clause.body = clause
+        .body
         .into_iter()
         .map(|stmt| transformer.visit_stmt_owned(stmt))
         .collect();
-    ast::ElifElseClause {
-        range,
-        node_index,
-        test,
-        body,
-    }
+    N::from(clause)
 }
 
 pub fn walk_f_string_owned<T: OwnedTransform + ?Sized>(
@@ -921,14 +882,16 @@ pub fn walk_t_string_owned<T: OwnedTransform + ?Sized>(
     }
 }
 
-pub fn walk_interpolated_string_element_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    element: ast::InterpolatedStringElement,
-) -> ast::InterpolatedStringElement {
-    match element {
+pub fn walk_interpolated_string_element_owned<T, N>(transformer: &T, element: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::InterpolatedStringElement>,
+{
+    let element = element.borrow().clone();
+    let element = match element {
         ast::InterpolatedStringElement::Interpolation(mut node) => {
-            let expr = (*node.expression).clone();
-            node.expression = Box::new(transformer.visit_expr_owned(expr));
+            let expression = node.expression;
+            node.expression = transformer.visit_expr_owned(expression);
             node.format_spec.as_mut().map(|spec| {
                 let spec_value = (**spec).clone();
                 **spec = transformer.visit_interpolated_string_format_spec_owned(spec_value);
@@ -938,15 +901,19 @@ pub fn walk_interpolated_string_element_owned<T: OwnedTransform + ?Sized>(
         ast::InterpolatedStringElement::Literal(node) => {
             ast::InterpolatedStringElement::Literal(node)
         }
-    }
+    };
+
+    N::from(element)
 }
 
-pub fn walk_interpolated_string_format_spec_owned<T: OwnedTransform + ?Sized>(
-    transformer: &T,
-    mut spec: ast::InterpolatedStringFormatSpec,
-) -> ast::InterpolatedStringFormatSpec {
+pub fn walk_interpolated_string_format_spec_owned<T, N>(transformer: &T, spec: N) -> N
+where
+    T: OwnedTransform + ?Sized,
+    N: OwnNode<ast::InterpolatedStringFormatSpec>,
+{
+    let mut spec = spec.borrow().clone();
     for element in &mut spec.elements {
         *element = transformer.visit_interpolated_string_element_owned(element.clone());
     }
-    spec
+    N::from(spec)
 }

--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -191,11 +191,7 @@ list({slice:expr})",
 }
 
 fn make_tuple_splat(tuple: ast::ExprTuple) -> Expr {
-    if !tuple
-        .elts
-        .iter()
-        .any(|elt| matches!(elt, Expr::Starred(_)))
-    {
+    if !tuple.elts.iter().any(|elt| matches!(elt, Expr::Starred(_))) {
         return Expr::Tuple(tuple);
     }
 


### PR DESCRIPTION
## Summary
- simplify the `OwnNode` trait back to a marker over `Borrow + From + Clone`
- restore owned walker helpers to clone nodes through `borrow()` instead of consuming wrappers

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae1d328f08324a958a50fa951f8ef