### PR TITLE
Use body_transform utilities for Transformer implementations

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -68,8 +68,8 @@ macro_rules! py_stmt {
     }};
 }
 
+use crate::body_transform::{walk_expr, walk_stmt, Transformer};
 use regex::Regex;
-use ruff_python_ast::visitor::transformer::{walk_expr, walk_stmt, Transformer};
 use ruff_python_ast::{self as ast, Expr, Stmt};
 use ruff_text_size::TextRange;
 use serde_json::Value;

--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -3,9 +3,9 @@ use super::{
     rewrite_expr_to_stmt, rewrite_for_loop, rewrite_import, rewrite_match_case, rewrite_string,
     rewrite_try_except, rewrite_with, Options,
 };
+use crate::body_transform::{walk_expr, walk_stmt, Transformer};
 use crate::template::{make_binop, make_generator, make_tuple, make_unaryop, single_stmt};
 use crate::{py_expr, py_stmt};
-use ruff_python_ast::visitor::transformer::{walk_expr, walk_stmt, Transformer};
 use ruff_python_ast::{self as ast, Expr, Operator, Stmt, UnaryOp};
 use ruff_text_size::TextRange;
 

--- a/src/transform/rewrite_class_def.rs
+++ b/src/transform/rewrite_class_def.rs
@@ -1,10 +1,9 @@
-use ruff_python_ast::visitor::transformer::{walk_expr, walk_stmt, Transformer};
+use crate::body_transform::{walk_expr, walk_stmt, Transformer};
+use crate::template::make_tuple;
+use crate::{py_expr, py_stmt};
 use ruff_python_ast::{self as ast, Expr, Stmt};
 use ruff_text_size::TextRange;
 use std::cell::Cell;
-
-use crate::template::make_tuple;
-use crate::{py_expr, py_stmt};
 
 struct MethodTransformer {
     uses_class: Cell<bool>,

--- a/src/transform/rewrite_complex_expr.rs
+++ b/src/transform/rewrite_complex_expr.rs
@@ -2,9 +2,9 @@ use std::cell::{Cell, RefCell};
 
 use super::context::Context;
 use super::rewrite_expr_to_stmt::{expr_boolop_to_stmts, expr_compare_to_stmts};
+use crate::body_transform::{walk_expr, walk_stmt, Transformer};
 use crate::template::{is_simple, single_stmt};
 use crate::{py_expr, py_stmt};
-use ruff_python_ast::visitor::transformer::{walk_expr, walk_stmt, Transformer};
 use ruff_python_ast::{self as ast, Expr, Stmt};
 
 pub(crate) struct UnnestExprTransformer<'a> {

--- a/src/transform/rewrite_expr_to_stmt.rs
+++ b/src/transform/rewrite_expr_to_stmt.rs
@@ -1,10 +1,10 @@
 use std::cell::RefCell;
 
 use super::context::Context;
+use crate::body_transform::{walk_expr, walk_stmt, Transformer};
 use crate::template::{make_binop, make_unaryop, single_stmt};
 use crate::{py_expr, py_stmt};
 use ruff_python_ast::name::Name;
-use ruff_python_ast::visitor::transformer::{walk_expr, walk_stmt, Transformer};
 use ruff_python_ast::{self as ast, CmpOp, Expr, Stmt};
 use ruff_text_size::TextRange;
 

--- a/src/transform/rewrite_for_loop.rs
+++ b/src/transform/rewrite_for_loop.rs
@@ -1,8 +1,7 @@
 use super::context::Context;
-use ruff_python_ast::visitor::transformer::Transformer;
-use ruff_python_ast::{self as ast, Stmt};
-
+use crate::body_transform::Transformer;
 use crate::py_stmt;
+use ruff_python_ast::{self as ast, Stmt};
 
 pub fn rewrite(
     ast::StmtFor {

--- a/src/transform/rewrite_with.rs
+++ b/src/transform/rewrite_with.rs
@@ -1,8 +1,7 @@
 use super::context::Context;
-use ruff_python_ast::visitor::transformer::Transformer;
-use ruff_python_ast::{self as ast, Stmt};
-
+use crate::body_transform::Transformer;
 use crate::{py_expr, py_stmt};
+use ruff_python_ast::{self as ast, Stmt};
 
 pub fn rewrite(
     ast::StmtWith {


### PR DESCRIPTION
## Summary
- update transformer implementations to import `Transformer`, `walk_expr`, and `walk_stmt` from the local `body_transform` module
- ensure helper rewrites reuse the crate's traversal utilities

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6e8f01f48324b64fe9056e1746e1