### PR TITLE
Document transform test file format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,13 @@
 - **MUST FOLLOW**: Use multi-line strings for Python templates and other test examples, beginning with a newline so the code starts on the second line, unless a single-line string is explicitly required by the previous rule.
 - **MUST FOLLOW**: Never add new variants to the minimal AST unless explicitly asked.
 - **MUST FOLLOW**: Always run `cargo test` and `pytest` before submitting changes.
+- **NOTE**: Transform tests go in a file named `test_module_name.txt`, containing zero or more blocks of the form:
+
+  ```
+  $ test name
+  Input module
+  =
+  Output module
+  ```
+
+- **MUST FOLLOW**: Ensure new transform modules include the test execution macro in their test block.


### PR DESCRIPTION
## Summary
- document where transform test fixtures live and the expected block format
- note that new transform modules must include the test execution macro in their test blocks

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc4823a88c8324b8c4f224bfb52000