### PR TITLE
Process buffered statements via visit_body

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod template;
 mod test_util;
 mod transform;
 
+use crate::body_transform::Transformer;
 use transform::{context::Context, expr::ExprRewriter, Options};
 
 fn should_skip(source: &str) -> bool {
@@ -70,7 +71,7 @@ fn apply_transforms(module: &mut ModModule, options: Options) {
     // `__dp__.<name>` calls with `getattr` in a single pass.
     let ctx = Context::new(options);
     let mut expr_transformer = ExprRewriter::new(&ctx);
-    expr_transformer.rewrite_body(&mut module.body);
+    expr_transformer.visit_body(&mut module.body);
 
     // Collapse `py_stmt!` templates after all rewrites.
     template::flatten(&mut module.body);

--- a/src/transform/rewrite_import.rs
+++ b/src/transform/rewrite_import.rs
@@ -69,6 +69,7 @@ pub fn rewrite_from(
 
 #[cfg(test)]
 mod tests {
+    use crate::body_transform::Transformer;
     use crate::transform::{context::Context, expr::ExprRewriter, ImportStarHandling, Options};
     use ruff_python_parser::parse_module;
 
@@ -78,7 +79,7 @@ mod tests {
         let mut module = parse_module(source).expect("parse error").into_syntax();
         let ctx = Context::new(options);
         let mut expr_transformer = ExprRewriter::new(&ctx);
-        expr_transformer.rewrite_body(&mut module.body);
+        expr_transformer.visit_body(&mut module.body);
         crate::template::flatten(&mut module.body);
         crate::ruff_ast_to_string(&module.body)
     }


### PR DESCRIPTION
## Summary
- recurse through buffered statements using `visit_body` so nested insertions receive full rewriting

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd7a724a048324a99c2ab5ff118aae