### PR TITLE
Guard transform recursion for specific statements

### DIFF
--- a/src/transform/rewrite_try_except.rs
+++ b/src/transform/rewrite_try_except.rs
@@ -82,7 +82,7 @@ finally:
     )
 }
 
-fn has_non_default_handler(stmt: &ast::StmtTry) -> bool {
+pub(crate) fn has_non_default_handler(stmt: &ast::StmtTry) -> bool {
     stmt.handlers.iter().any(|handler| {
         matches!(
             handler,


### PR DESCRIPTION
## Summary
- move the FunctionDef branch into the primary `visit_stmt` match and gate it on decorator presence to avoid recursive rewrites
- guard the Try, Raise, and Assign rewrite arms and revisit simple assignments after walking to keep expression lowers idempotent
- expose `has_non_default_handler` from `rewrite_try_except` so it can be reused for the Try guard

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd86e922788324bab0f10506127742