### PR TITLE
Refine raise-from rewrite handling

### DIFF
--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -702,14 +702,12 @@ impl<'a> Transformer for ExprRewriter<'a> {
                 match (raise.exc.take(), raise.cause.take()) {
                     (Some(exc), Some(cause)) => py_stmt!(
                         "raise __dp__.raise_from({exc:expr}, {cause:expr})",
-                        exc = *exc.clone(),
-                        cause = *cause.clone(),
+                        exc = *exc,
+                        cause = *cause,
                     ),
-                    (exc, cause) => {
-                        raise.exc = exc;
-                        raise.cause = cause;
-                        Stmt::Raise(raise)
-                    }
+                    _ => panic!(
+                        "raise with a cause but without an exception should be impossible"
+                    ),
                 }
             }
             stmt => stmt,


### PR DESCRIPTION
## Summary
- always take the raise cause and expect it to exist when rewriting raise-from
- panic if the rewriter sees a cause without an accompanying exception
- simplify the raise-from rewrite by matching on the exception and cause together

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd91ea144c8324a804198caad00b2d