### PR TITLE
Hoist named expressions during expression rewriting

### DIFF
--- a/src/transform/rewrite_complex_expr.rs
+++ b/src/transform/rewrite_complex_expr.rs
@@ -30,24 +30,6 @@ impl<'a> Transformer for UnnestExprTransformer<'a> {
         walk_expr(self, expr);
         if !is_simple(expr) {
             match expr {
-                Expr::Named(named_expr) => {
-                    let tmp = self.ctx.fresh("tmp");
-                    let ast::ExprNamed { target, value, .. } = named_expr.clone();
-                    let assign_tmp = py_stmt!(
-                        "\n{tmp:id} = {value:expr}\n",
-                        tmp = tmp.as_str(),
-                        value = *value,
-                    );
-                    let assign_target = py_stmt!(
-                        "\n{target:expr} = {tmp:id}\n",
-                        target = *target,
-                        tmp = tmp.as_str(),
-                    );
-                    let mut stmts = self.stmts.borrow_mut();
-                    stmts.push(assign_tmp);
-                    stmts.push(assign_target);
-                    *expr = py_expr!("{tmp:id}", tmp = tmp.as_str());
-                }
                 Expr::If(if_expr) => {
                     let tmp = self.ctx.fresh("tmp");
                     let ast::ExprIf {

--- a/src/transform/tests_rewrite_complex_expr.txt
+++ b/src/transform/tests_rewrite_complex_expr.txt
@@ -25,7 +25,9 @@ $ rewrites named expression in boolop
 if (y := foo()) and bar:
     pass
 =
-_dp_tmp_1 = (y := foo())
+_dp_tmp_2 = foo()
+y = _dp_tmp_2
+_dp_tmp_1 = _dp_tmp_2
 if _dp_tmp_1:
     _dp_tmp_1 = bar
 if _dp_tmp_1:


### PR DESCRIPTION
## Summary
- lower named expressions while rewriting expressions so temporaries live in the statement buffer
- simplify UnnestExprTransformer by relying on the common lowering logic
- update the complex expression transform fixture to reflect the new lowering order

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd9aa523748324906af0b019c31f89