### PR TITLE
Handle conditional expressions in expr rewriter

### DIFF
--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -382,6 +382,21 @@ impl<'a> Transformer for ExprRewriter<'a> {
                 self.buf.push(assign_target);
                 py_expr!("{tmp:id}", tmp = tmp.as_str())
             }
+            Expr::If(if_expr) => {
+                let tmp = self.ctx.fresh("tmp");
+                let ast::ExprIf {
+                    test, body, orelse, ..
+                } = if_expr;
+                let assign = py_stmt!(
+                    "\nif {cond:expr}:\n    {tmp:id} = {body:expr}\nelse:\n    {tmp:id} = {orelse:expr}",
+                    cond = *test,
+                    tmp = tmp.as_str(),
+                    body = *body,
+                    orelse = *orelse,
+                );
+                self.buf.push(assign);
+                py_expr!("{tmp:id}", tmp = tmp.as_str())
+            }
             Expr::BoolOp(bool_op) => {
                 let tmp = self.ctx.fresh("tmp");
                 let stmts = expr_boolop_to_stmts(tmp.as_str(), bool_op);

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -413,14 +413,11 @@ $ expr 053
 
 =
 
-_dp_tmp_1 = f()
-_dp_tmp_2 = __dp__.add(a, 1)
-_dp_tmp_3 = __dp__.add(b, 2)
-if _dp_tmp_1:
-    _dp_tmp_4 = _dp_tmp_2
+if f():
+    _dp_tmp_1 = __dp__.add(a, 1)
 else:
-    _dp_tmp_4 = _dp_tmp_3
-_dp_tmp_4
+    _dp_tmp_1 = __dp__.add(b, 2)
+_dp_tmp_1
 
 
 $ expr 054


### PR DESCRIPTION
## Summary
- hoist conditional expression lowering into the expression rewriter buffer
- avoid unnesting conditional expressions in rewrite_complex_expr now that they are handled earlier
- update expr fixture to reflect the new lowering strategy

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda31097ac8324a4ef884c1dd5df21