### PR TITLE
Handle compare unnesting in expression rewriter

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -93,12 +93,21 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
-_dp_tmp_13 = range(5)
-_dp_tmp_14 = __dp__.mod(i, 2)
-_dp_tmp_15 = __dp__.eq(_dp_tmp_14, 0)
-_dp_tmp_16 = __dp__.add(i, 1)
-def _dp_gen_18(_dp_tmp_13):
-    _dp_iter_19 = __dp__.iter(_dp_tmp_13)
+def _dp_gen_13(_dp_iter_14):
+    _dp_iter_15 = __dp__.iter(_dp_iter_14)
+    while True:
+        try:
+            i = __dp__.next(_dp_iter_15)
+        except:
+            __dp__.check_stopiteration()
+            break
+        else:
+            _dp_tmp_16 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_16:
+                yield __dp__.add(i, 1)
+x = list(_dp_gen_13(__dp__.iter(range(5))))
+def _dp_gen_17(_dp_iter_18):
+    _dp_iter_19 = __dp__.iter(_dp_iter_18)
     while True:
         try:
             i = __dp__.next(_dp_iter_19)
@@ -106,41 +115,20 @@ def _dp_gen_18(_dp_tmp_13):
             __dp__.check_stopiteration()
             break
         else:
-            if _dp_tmp_15:
-                yield _dp_tmp_16
-_dp_tmp_17 = list(_dp_gen_18(__dp__.iter(_dp_tmp_13)))
-x = _dp_tmp_17
-_dp_tmp_20 = range(5)
-_dp_tmp_21 = __dp__.mod(i, 2)
-_dp_tmp_22 = __dp__.eq(_dp_tmp_21, 0)
-_dp_tmp_23 = __dp__.add(i, 1)
-def _dp_gen_25(_dp_tmp_20):
-    _dp_iter_26 = __dp__.iter(_dp_tmp_20)
+            _dp_tmp_20 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_20:
+                yield __dp__.add(i, 1)
+y = set(_dp_gen_17(__dp__.iter(range(5))))
+def _dp_gen_21(_dp_iter_22):
+    _dp_iter_23 = __dp__.iter(_dp_iter_22)
     while True:
         try:
-            i = __dp__.next(_dp_iter_26)
+            i = __dp__.next(_dp_iter_23)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            if _dp_tmp_22:
-                yield _dp_tmp_23
-_dp_tmp_24 = set(_dp_gen_25(__dp__.iter(_dp_tmp_20)))
-y = _dp_tmp_24
-_dp_tmp_27 = range(5)
-_dp_tmp_28 = __dp__.mod(i, 2)
-_dp_tmp_29 = __dp__.eq(_dp_tmp_28, 0)
-_dp_tmp_30 = __dp__.add(i, 1)
-def _dp_gen_32(_dp_tmp_27):
-    _dp_iter_33 = __dp__.iter(_dp_tmp_27)
-    while True:
-        try:
-            i = __dp__.next(_dp_iter_33)
-        except:
-            __dp__.check_stopiteration()
-            break
-        else:
-            if _dp_tmp_29:
-                yield _dp_tmp_30
-_dp_tmp_31 = _dp_gen_32(__dp__.iter(_dp_tmp_27))
-z = _dp_tmp_31
+            _dp_tmp_24 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_24:
+                yield __dp__.add(i, 1)
+z = _dp_gen_21(__dp__.iter(range(5)))

--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -1,7 +1,9 @@
 use super::{
-    context::Context, rewrite_assert, rewrite_class_def, rewrite_complex_expr, rewrite_decorator,
-    rewrite_expr_to_stmt::expr_boolop_to_stmts, rewrite_for_loop, rewrite_import,
-    rewrite_match_case, rewrite_string, rewrite_try_except, rewrite_with, Options,
+    context::Context,
+    rewrite_assert, rewrite_class_def, rewrite_complex_expr, rewrite_decorator,
+    rewrite_expr_to_stmt::{expr_boolop_to_stmts, expr_compare_to_stmts},
+    rewrite_for_loop, rewrite_import, rewrite_match_case, rewrite_string, rewrite_try_except,
+    rewrite_with, Options,
 };
 use crate::body_transform::{walk_expr, walk_stmt, Transformer};
 use crate::template::{make_binop, make_generator, make_tuple, make_unaryop, single_stmt};
@@ -400,6 +402,12 @@ impl<'a> Transformer for ExprRewriter<'a> {
             Expr::BoolOp(bool_op) => {
                 let tmp = self.ctx.fresh("tmp");
                 let stmts = expr_boolop_to_stmts(tmp.as_str(), bool_op);
+                self.buf.extend(stmts);
+                py_expr!("{tmp:id}", tmp = tmp.as_str())
+            }
+            Expr::Compare(compare) => {
+                let tmp = self.ctx.fresh("tmp");
+                let stmts = expr_compare_to_stmts(tmp.as_str(), compare);
                 self.buf.extend(stmts);
                 py_expr!("{tmp:id}", tmp = tmp.as_str())
             }

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -301,23 +301,21 @@ $ expr 041
 r = {k: v + 1 for k, v in items if k % 2 == 0}
 =
 
-_dp_tmp_1 = k, v
-_dp_tmp_2 = __dp__.mod(k, 2)
-_dp_tmp_3 = __dp__.eq(_dp_tmp_2, 0)
-_dp_tmp_4 = __dp__.add(v, 1)
-def _dp_gen_6(items):
-    _dp_iter_7 = __dp__.iter(items)
+def _dp_gen_1(items):
+    _dp_iter_2 = __dp__.iter(items)
     while True:
         try:
-            _dp_tmp_1 = __dp__.next(_dp_iter_7)
+            _dp_tmp_3 = __dp__.next(_dp_iter_2)
+            k = __dp__.getitem(_dp_tmp_3, 0)
+            v = __dp__.getitem(_dp_tmp_3, 1)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            if _dp_tmp_3:
-                yield k, _dp_tmp_4
-_dp_tmp_5 = dict(_dp_gen_6(__dp__.iter(items)))
-r = _dp_tmp_5
+            _dp_tmp_4 = __dp__.eq(__dp__.mod(k, 2), 0)
+            if _dp_tmp_4:
+                yield k, __dp__.add(v, 1)
+r = dict(_dp_gen_1(__dp__.iter(items)))
 
 
 $ expr 042
@@ -382,22 +380,19 @@ $ expr 051
 r = [a + 1 for a in items if a % 2 == 0]
 =
 
-_dp_tmp_1 = __dp__.mod(a, 2)
-_dp_tmp_2 = __dp__.eq(_dp_tmp_1, 0)
-_dp_tmp_3 = __dp__.add(a, 1)
-def _dp_gen_5(items):
-    _dp_iter_6 = __dp__.iter(items)
+def _dp_gen_1(items):
+    _dp_iter_2 = __dp__.iter(items)
     while True:
         try:
-            a = __dp__.next(_dp_iter_6)
+            a = __dp__.next(_dp_iter_2)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            if _dp_tmp_2:
-                yield _dp_tmp_3
-_dp_tmp_4 = list(_dp_gen_5(__dp__.iter(items)))
-r = _dp_tmp_4
+            _dp_tmp_3 = __dp__.eq(__dp__.mod(a, 2), 0)
+            if _dp_tmp_3:
+                yield __dp__.add(a, 1)
+r = list(_dp_gen_1(__dp__.iter(items)))
 
 
 $ expr 052

--- a/src/transform/tests_rewrite_complex_expr.txt
+++ b/src/transform/tests_rewrite_complex_expr.txt
@@ -5,11 +5,8 @@ x = yield from y
 _dp_yield_from_state_1 = __dp__.yield_from_init(y)
 _dp_yield_from_sent_2 = None
 while True:
-    _dp_tmp_4 = __dp__.getitem
-    _dp_tmp_5 = _dp_tmp_4(_dp_yield_from_state_1, 0)
-    _dp_tmp_6 = __dp__.RUNNING
-    _dp_tmp_7 = __dp__.ne(_dp_tmp_5, _dp_tmp_6)
-    if _dp_tmp_7:
+    _dp_tmp_4 = __dp__.ne(__dp__.getitem(_dp_yield_from_state_1, 0), __dp__.RUNNING)
+    if _dp_tmp_4:
         break
     try:
         _dp_yield_from_sent_2 = yield __dp__.getitem(_dp_yield_from_state_1, 1)

--- a/src/transform/tests_rewrite_match_case.txt
+++ b/src/transform/tests_rewrite_match_case.txt
@@ -11,16 +11,13 @@ match x:
 _dp_match_1 = x
 _dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
 if _dp_tmp_2:
-    _dp_tmp_3 = a()
-    _dp_tmp_3
+    a()
 else:
-    _dp_tmp_4 = __dp__.eq(_dp_match_1, 2)
-    if _dp_tmp_4:
-        _dp_tmp_5 = b()
-        _dp_tmp_5
+    _dp_tmp_3 = __dp__.eq(_dp_match_1, 2)
+    if _dp_tmp_3:
+        b()
     else:
-        _dp_tmp_6 = c()
-        _dp_tmp_6
+        c()
 
 $ rewrites match with guard
 
@@ -31,17 +28,14 @@ match x:
         b()
 =
 _dp_match_1 = x
-_dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
-_dp_tmp_6 = _dp_tmp_2
-if _dp_tmp_6:
-    _dp_tmp_6 = cond
-_dp_tmp_3 = _dp_tmp_6
-if _dp_tmp_3:
-    _dp_tmp_4 = a()
-    _dp_tmp_4
+_dp_tmp_3 = __dp__.eq(_dp_match_1, 1)
+_dp_tmp_2 = _dp_tmp_3
+if _dp_tmp_2:
+    _dp_tmp_2 = cond
+if _dp_tmp_2:
+    a()
 else:
-    _dp_tmp_5 = b()
-    _dp_tmp_5
+    b()
 
 $ rewrites match or pattern
 
@@ -52,18 +46,15 @@ match x:
         b()
 =
 _dp_match_1 = x
-_dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
-_dp_tmp_3 = __dp__.eq(_dp_match_1, 2)
-_dp_tmp_7 = _dp_tmp_2
-if __dp__.not_(_dp_tmp_7):
-    _dp_tmp_7 = _dp_tmp_3
-_dp_tmp_4 = _dp_tmp_7
-if _dp_tmp_4:
-    _dp_tmp_5 = a()
-    _dp_tmp_5
+_dp_tmp_3 = __dp__.eq(_dp_match_1, 1)
+_dp_tmp_2 = _dp_tmp_3
+if __dp__.not_(_dp_tmp_2):
+    _dp_tmp_4 = __dp__.eq(_dp_match_1, 2)
+    _dp_tmp_2 = _dp_tmp_4
+if _dp_tmp_2:
+    a()
 else:
-    _dp_tmp_6 = b()
-    _dp_tmp_6
+    b()
 
 $ rewrites match singleton
 
@@ -76,11 +67,9 @@ match x:
 _dp_match_1 = x
 _dp_tmp_2 = __dp__.is_(_dp_match_1, None)
 if _dp_tmp_2:
-    _dp_tmp_3 = a()
-    _dp_tmp_3
+    a()
 else:
-    _dp_tmp_4 = b()
-    _dp_tmp_4
+    b()
 
 $ rewrites match as pattern
 
@@ -94,11 +83,9 @@ _dp_match_1 = x
 _dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
 if _dp_tmp_2:
     y = _dp_match_1
-    _dp_tmp_3 = a()
-    _dp_tmp_3
+    a()
 else:
-    _dp_tmp_4 = b()
-    _dp_tmp_4
+    b()
 
 $ rewrites match capture pattern
 
@@ -111,12 +98,10 @@ match x:
 _dp_match_1 = x
 _dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
 if _dp_tmp_2:
-    _dp_tmp_3 = a()
-    _dp_tmp_3
+    a()
 else:
     y = _dp_match_1
-    _dp_tmp_4 = b()
-    _dp_tmp_4
+    b()
 
 $ rewrites match class with match args
 
@@ -128,34 +113,18 @@ match x:
 =
 _dp_match_1 = x
 _dp_tmp_2 = isinstance(_dp_match_1, C)
-_dp_tmp_3 = C.__match_args__
-_dp_tmp_4 = __dp__.getitem(_dp_tmp_3, 0)
-_dp_tmp_5 = hasattr(_dp_match_1, _dp_tmp_4)
-_dp_tmp_6 = C.__match_args__
-_dp_tmp_7 = __dp__.getitem(_dp_tmp_6, 0)
-_dp_tmp_8 = getattr(_dp_match_1, _dp_tmp_7)
-_dp_tmp_9 = __dp__.eq(_dp_tmp_8, 1)
-_dp_tmp_10 = C.__match_args__
-_dp_tmp_11 = __dp__.getitem(_dp_tmp_10, 1)
-_dp_tmp_12 = hasattr(_dp_match_1, _dp_tmp_11)
-_dp_tmp_19 = _dp_tmp_2
-if _dp_tmp_19:
-    _dp_tmp_19 = _dp_tmp_5
-if _dp_tmp_19:
-    _dp_tmp_19 = _dp_tmp_9
-if _dp_tmp_19:
-    _dp_tmp_19 = _dp_tmp_12
-_dp_tmp_13 = _dp_tmp_19
-if _dp_tmp_13:
-    _dp_tmp_14 = C.__match_args__
-    _dp_tmp_15 = __dp__.getitem(_dp_tmp_14, 1)
-    _dp_tmp_16 = getattr(_dp_match_1, _dp_tmp_15)
-    b = _dp_tmp_16
-    _dp_tmp_17 = a()
-    _dp_tmp_17
+if _dp_tmp_2:
+    _dp_tmp_2 = hasattr(_dp_match_1, __dp__.getitem(C.__match_args__, 0))
+if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.eq(getattr(_dp_match_1, __dp__.getitem(C.__match_args__, 0)), 1)
+    _dp_tmp_2 = _dp_tmp_3
+if _dp_tmp_2:
+    _dp_tmp_2 = hasattr(_dp_match_1, __dp__.getitem(C.__match_args__, 1))
+if _dp_tmp_2:
+    b = getattr(_dp_match_1, __dp__.getitem(C.__match_args__, 1))
+    a()
 else:
-    _dp_tmp_18 = c()
-    _dp_tmp_18
+    c()
 
 $ rewrites match sequence pattern
 
@@ -167,32 +136,21 @@ match x:
 =
 _dp_match_1 = x
 _dp_tmp_2 = hasattr(_dp_match_1, '__len__')
-_dp_tmp_3 = hasattr(_dp_match_1, '__getitem__')
-_dp_tmp_4 = str, bytes, bytearray
-_dp_tmp_5 = isinstance(_dp_match_1, _dp_tmp_4)
-_dp_tmp_6 = __dp__.not_(_dp_tmp_5)
-_dp_tmp_7 = len(_dp_match_1)
-_dp_tmp_8 = __dp__.eq(_dp_tmp_7, 2)
-_dp_tmp_9 = __dp__.getitem(_dp_match_1, 1)
-_dp_tmp_10 = __dp__.eq(_dp_tmp_9, 2)
-_dp_tmp_15 = _dp_tmp_2
-if _dp_tmp_15:
-    _dp_tmp_15 = _dp_tmp_3
-if _dp_tmp_15:
-    _dp_tmp_15 = _dp_tmp_6
-if _dp_tmp_15:
-    _dp_tmp_15 = _dp_tmp_8
-if _dp_tmp_15:
-    _dp_tmp_15 = _dp_tmp_10
-_dp_tmp_11 = _dp_tmp_15
-if _dp_tmp_11:
-    _dp_tmp_12 = __dp__.getitem(_dp_match_1, 0)
-    a = _dp_tmp_12
-    _dp_tmp_13 = a()
-    _dp_tmp_13
+if _dp_tmp_2:
+    _dp_tmp_2 = hasattr(_dp_match_1, '__getitem__')
+if _dp_tmp_2:
+    _dp_tmp_2 = __dp__.not_(isinstance(_dp_match_1, (str, bytes, bytearray)))
+if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.eq(len(_dp_match_1), 2)
+    _dp_tmp_2 = _dp_tmp_3
+if _dp_tmp_2:
+    _dp_tmp_4 = __dp__.eq(__dp__.getitem(_dp_match_1, 1), 2)
+    _dp_tmp_2 = _dp_tmp_4
+if _dp_tmp_2:
+    a = __dp__.getitem(_dp_match_1, 0)
+    a()
 else:
-    _dp_tmp_14 = b()
-    _dp_tmp_14
+    b()
 
 $ rewrites match sequence with star
 
@@ -204,38 +162,20 @@ match x:
 =
 _dp_match_1 = x
 _dp_tmp_2 = hasattr(_dp_match_1, '__len__')
-_dp_tmp_3 = hasattr(_dp_match_1, '__getitem__')
-_dp_tmp_4 = str, bytes, bytearray
-_dp_tmp_5 = isinstance(_dp_match_1, _dp_tmp_4)
-_dp_tmp_6 = __dp__.not_(_dp_tmp_5)
-_dp_tmp_7 = len(_dp_match_1)
-_dp_tmp_8 = __dp__.ge(_dp_tmp_7, 2)
-_dp_tmp_21 = _dp_tmp_2
-if _dp_tmp_21:
-    _dp_tmp_21 = _dp_tmp_3
-if _dp_tmp_21:
-    _dp_tmp_21 = _dp_tmp_6
-if _dp_tmp_21:
-    _dp_tmp_21 = _dp_tmp_8
-_dp_tmp_9 = _dp_tmp_21
-if _dp_tmp_9:
-    _dp_tmp_10 = __dp__.getitem(_dp_match_1, 0)
-    first = _dp_tmp_10
-    _dp_tmp_11 = len(_dp_match_1)
-    _dp_tmp_12 = __dp__.sub(_dp_tmp_11, 1)
-    _dp_tmp_13 = slice(1, _dp_tmp_12, None)
-    _dp_tmp_14 = __dp__.getitem(_dp_match_1, _dp_tmp_13)
-    _dp_tmp_15 = list(_dp_tmp_14)
-    rest = _dp_tmp_15
-    _dp_tmp_16 = len(_dp_match_1)
-    _dp_tmp_17 = __dp__.sub(_dp_tmp_16, 1)
-    _dp_tmp_18 = __dp__.getitem(_dp_match_1, _dp_tmp_17)
-    last = _dp_tmp_18
-    _dp_tmp_19 = a()
-    _dp_tmp_19
+if _dp_tmp_2:
+    _dp_tmp_2 = hasattr(_dp_match_1, '__getitem__')
+if _dp_tmp_2:
+    _dp_tmp_2 = __dp__.not_(isinstance(_dp_match_1, (str, bytes, bytearray)))
+if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.ge(len(_dp_match_1), 2)
+    _dp_tmp_2 = _dp_tmp_3
+if _dp_tmp_2:
+    first = __dp__.getitem(_dp_match_1, 0)
+    rest = list(__dp__.getitem(_dp_match_1, slice(1, __dp__.sub(len(_dp_match_1), 1), None)))
+    last = __dp__.getitem(_dp_match_1, __dp__.sub(len(_dp_match_1), 1))
+    a()
 else:
-    _dp_tmp_20 = b()
-    _dp_tmp_20
+    b()
 
 $ rewrites match mapping pattern
 
@@ -247,37 +187,25 @@ match x:
 =
 _dp_match_1 = x
 _dp_tmp_2 = hasattr(_dp_match_1, 'keys')
-_dp_tmp_3 = hasattr(_dp_match_1, '__getitem__')
-_dp_tmp_4 = __dp__.contains(_dp_match_1, "a")
-_dp_tmp_5 = __dp__.contains(_dp_match_1, "b")
-_dp_tmp_6 = __dp__.getitem(_dp_match_1, "b")
-_dp_tmp_7 = __dp__.eq(_dp_tmp_6, 2)
-_dp_tmp_17 = _dp_tmp_2
-if _dp_tmp_17:
-    _dp_tmp_17 = _dp_tmp_3
-if _dp_tmp_17:
-    _dp_tmp_17 = _dp_tmp_4
-if _dp_tmp_17:
-    _dp_tmp_17 = _dp_tmp_5
-if _dp_tmp_17:
-    _dp_tmp_17 = _dp_tmp_7
-_dp_tmp_8 = _dp_tmp_17
-if _dp_tmp_8:
-    _dp_tmp_9 = __dp__.getitem(_dp_match_1, "a")
-    a = _dp_tmp_9
-    _dp_tmp_10 = dict(_dp_match_1)
-    rest = _dp_tmp_10
-    _dp_tmp_11 = rest.pop
-    _dp_tmp_12 = _dp_tmp_11("a", None)
-    _dp_tmp_12
-    _dp_tmp_13 = rest.pop
-    _dp_tmp_14 = _dp_tmp_13("b", None)
-    _dp_tmp_14
-    _dp_tmp_15 = a()
-    _dp_tmp_15
+if _dp_tmp_2:
+    _dp_tmp_2 = hasattr(_dp_match_1, '__getitem__')
+if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.contains(_dp_match_1, "a")
+    _dp_tmp_2 = _dp_tmp_3
+if _dp_tmp_2:
+    _dp_tmp_4 = __dp__.contains(_dp_match_1, "b")
+    _dp_tmp_2 = _dp_tmp_4
+if _dp_tmp_2:
+    _dp_tmp_5 = __dp__.eq(__dp__.getitem(_dp_match_1, "b"), 2)
+    _dp_tmp_2 = _dp_tmp_5
+if _dp_tmp_2:
+    a = __dp__.getitem(_dp_match_1, "a")
+    rest = dict(_dp_match_1)
+    rest.pop("a", None)
+    rest.pop("b", None)
+    a()
 else:
-    _dp_tmp_16 = b()
-    _dp_tmp_16
+    b()
 
 $ rewrites match or with assignments
 
@@ -289,85 +217,48 @@ match x:
 =
 _dp_match_1 = x
 _dp_tmp_2 = hasattr(_dp_match_1, '__len__')
-_dp_tmp_3 = hasattr(_dp_match_1, '__getitem__')
-_dp_tmp_4 = str, bytes, bytearray
-_dp_tmp_5 = isinstance(_dp_match_1, _dp_tmp_4)
-_dp_tmp_6 = __dp__.not_(_dp_tmp_5)
-_dp_tmp_7 = len(_dp_match_1)
-_dp_tmp_8 = __dp__.eq(_dp_tmp_7, 2)
-_dp_tmp_41 = _dp_tmp_2
-if _dp_tmp_41:
-    _dp_tmp_41 = _dp_tmp_3
-if _dp_tmp_41:
-    _dp_tmp_41 = _dp_tmp_6
-if _dp_tmp_41:
-    _dp_tmp_41 = _dp_tmp_8
-_dp_tmp_9 = _dp_tmp_41
-_dp_tmp_10 = hasattr(_dp_match_1, '__len__')
-_dp_tmp_11 = hasattr(_dp_match_1, '__getitem__')
-_dp_tmp_12 = str, bytes, bytearray
-_dp_tmp_13 = isinstance(_dp_match_1, _dp_tmp_12)
-_dp_tmp_14 = __dp__.not_(_dp_tmp_13)
-_dp_tmp_15 = len(_dp_match_1)
-_dp_tmp_16 = __dp__.eq(_dp_tmp_15, 2)
-_dp_tmp_42 = _dp_tmp_10
-if _dp_tmp_42:
-    _dp_tmp_42 = _dp_tmp_11
-if _dp_tmp_42:
-    _dp_tmp_42 = _dp_tmp_14
-if _dp_tmp_42:
-    _dp_tmp_42 = _dp_tmp_16
-_dp_tmp_17 = _dp_tmp_42
-_dp_tmp_43 = _dp_tmp_9
-if __dp__.not_(_dp_tmp_43):
-    _dp_tmp_43 = _dp_tmp_17
-_dp_tmp_18 = _dp_tmp_43
-if _dp_tmp_18:
-    _dp_tmp_19 = hasattr(_dp_match_1, '__len__')
-    _dp_tmp_20 = hasattr(_dp_match_1, '__getitem__')
-    _dp_tmp_21 = str, bytes, bytearray
-    _dp_tmp_22 = isinstance(_dp_match_1, _dp_tmp_21)
-    _dp_tmp_23 = __dp__.not_(_dp_tmp_22)
-    _dp_tmp_24 = len(_dp_match_1)
-    _dp_tmp_25 = __dp__.eq(_dp_tmp_24, 2)
-    _dp_tmp_44 = _dp_tmp_19
-    if _dp_tmp_44:
-        _dp_tmp_44 = _dp_tmp_20
-    if _dp_tmp_44:
-        _dp_tmp_44 = _dp_tmp_23
-    if _dp_tmp_44:
-        _dp_tmp_44 = _dp_tmp_25
-    _dp_tmp_26 = _dp_tmp_44
-    if _dp_tmp_26:
-        _dp_tmp_27 = __dp__.getitem(_dp_match_1, 0)
-        a = _dp_tmp_27
-        _dp_tmp_28 = __dp__.getitem(_dp_match_1, 1)
-        b = _dp_tmp_28
+if _dp_tmp_2:
+    _dp_tmp_2 = hasattr(_dp_match_1, '__getitem__')
+if _dp_tmp_2:
+    _dp_tmp_2 = __dp__.not_(isinstance(_dp_match_1, (str, bytes, bytearray)))
+if _dp_tmp_2:
+    _dp_tmp_7 = __dp__.eq(len(_dp_match_1), 2)
+    _dp_tmp_2 = _dp_tmp_7
+if __dp__.not_(_dp_tmp_2):
+    _dp_tmp_2 = hasattr(_dp_match_1, '__len__')
+    if _dp_tmp_2:
+        _dp_tmp_2 = hasattr(_dp_match_1, '__getitem__')
+    if _dp_tmp_2:
+        _dp_tmp_2 = __dp__.not_(isinstance(_dp_match_1, (str, bytes, bytearray)))
+    if _dp_tmp_2:
+        _dp_tmp_8 = __dp__.eq(len(_dp_match_1), 2)
+        _dp_tmp_2 = _dp_tmp_8
+if _dp_tmp_2:
+    _dp_tmp_3 = hasattr(_dp_match_1, '__len__')
+    if _dp_tmp_3:
+        _dp_tmp_3 = hasattr(_dp_match_1, '__getitem__')
+    if _dp_tmp_3:
+        _dp_tmp_3 = __dp__.not_(isinstance(_dp_match_1, (str, bytes, bytearray)))
+    if _dp_tmp_3:
+        _dp_tmp_6 = __dp__.eq(len(_dp_match_1), 2)
+        _dp_tmp_3 = _dp_tmp_6
+    if _dp_tmp_3:
+        a = __dp__.getitem(_dp_match_1, 0)
+        b = __dp__.getitem(_dp_match_1, 1)
     else:
-        _dp_tmp_29 = hasattr(_dp_match_1, '__len__')
-        _dp_tmp_30 = hasattr(_dp_match_1, '__getitem__')
-        _dp_tmp_31 = str, bytes, bytearray
-        _dp_tmp_32 = isinstance(_dp_match_1, _dp_tmp_31)
-        _dp_tmp_33 = __dp__.not_(_dp_tmp_32)
-        _dp_tmp_34 = len(_dp_match_1)
-        _dp_tmp_35 = __dp__.eq(_dp_tmp_34, 2)
-        _dp_tmp_45 = _dp_tmp_29
-        if _dp_tmp_45:
-            _dp_tmp_45 = _dp_tmp_30
-        if _dp_tmp_45:
-            _dp_tmp_45 = _dp_tmp_33
-        if _dp_tmp_45:
-            _dp_tmp_45 = _dp_tmp_35
-        _dp_tmp_36 = _dp_tmp_45
-        if _dp_tmp_36:
-            _dp_tmp_37 = __dp__.getitem(_dp_match_1, 0)
-            a = _dp_tmp_37
-            _dp_tmp_38 = __dp__.getitem(_dp_match_1, 1)
-            b = _dp_tmp_38
+        _dp_tmp_4 = hasattr(_dp_match_1, '__len__')
+        if _dp_tmp_4:
+            _dp_tmp_4 = hasattr(_dp_match_1, '__getitem__')
+        if _dp_tmp_4:
+            _dp_tmp_4 = __dp__.not_(isinstance(_dp_match_1, (str, bytes, bytearray)))
+        if _dp_tmp_4:
+            _dp_tmp_5 = __dp__.eq(len(_dp_match_1), 2)
+            _dp_tmp_4 = _dp_tmp_5
+        if _dp_tmp_4:
+            a = __dp__.getitem(_dp_match_1, 0)
+            b = __dp__.getitem(_dp_match_1, 1)
         else:
             pass
-    _dp_tmp_39 = a()
-    _dp_tmp_39
+    a()
 else:
-    _dp_tmp_40 = b()
-    _dp_tmp_40
+    b()


### PR DESCRIPTION
## Summary
- hoist comparison expressions via `ExprRewriter`, letting the transformer emit temporary statements instead of relying on the unnest pass
- simplify the unnesting logic to focus on `yield from` and refresh the desugared example output and fixtures for comparisons and comprehensions

## Testing
- `cargo fmt`
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cda572f1f88324ba0b6830b442f317