### PR TITLE
Extract truthy rewrite into dedicated pass

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,10 @@ fn apply_transforms(module: &mut ModModule, options: Options) {
     // Collapse `py_stmt!` templates after all rewrites.
     template::flatten(&mut module.body);
 
+    if options.truthy {
+        transform::rewrite_truthy::rewrite(&mut module.body);
+    }
+
     strip_type_aliases(&mut module.body);
 }
 

--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -28,20 +28,6 @@ impl<'a> ExprRewriter<'a> {
         }
     }
 
-    fn wrap_truthy_expr(&mut self, expr: &mut Expr) {
-        if !self.options.truthy || is_truth_call(expr) {
-            return;
-        }
-
-        let original = expr.clone();
-        *expr = py_expr!(
-            "
-__dp__.truth({expr:expr})
-",
-            expr = original,
-        );
-    }
-
     fn lower_lambda(&mut self, lambda: ast::ExprLambda) -> Expr {
         let func_name = self.ctx.fresh("lambda");
 
@@ -768,102 +754,10 @@ impl<'a> Transformer for ExprRewriter<'a> {
         }
 
         walk_stmt(self, stmt);
-
-        if self.options.truthy {
-            match stmt {
-                Stmt::If(ast::StmtIf {
-                    test,
-                    elif_else_clauses,
-                    ..
-                }) => {
-                    self.wrap_truthy_expr(test);
-                    for clause in elif_else_clauses {
-                        if let Some(test) = &mut clause.test {
-                            self.wrap_truthy_expr(test);
-                        }
-                    }
-                }
-                Stmt::While(ast::StmtWhile { test, .. }) => {
-                    self.wrap_truthy_expr(test);
-                }
-                _ => {}
-            }
-        }
-    }
-}
-
-fn is_truth_call(expr: &Expr) -> bool {
-    match expr {
-        Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) if arguments.args.len() == 1 && arguments.keywords.is_empty() => match func.as_ref() {
-            Expr::Attribute(ast::ExprAttribute { value, attr, .. }) if attr.as_str() == "truth" => {
-                matches!(
-                    value.as_ref(),
-                    Expr::Name(ast::ExprName { id, .. })
-                        if id.as_str() == "__dp__"
-                )
-            }
-            _ => false,
-        },
-        _ => false,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test_util::assert_transform_eq_truthy;
-
     crate::transform_fixture_test!("tests_expr.txt");
-
-    #[test]
-    fn rewrites_truthy_if_condition() {
-        let input = r#"
-if a:
-    pass
-else:
-    pass
-"#;
-        let expected = r#"
-if __dp__.truth(a):
-    pass
-else:
-    pass
-"#;
-        assert_transform_eq_truthy(input, expected);
-    }
-
-    #[test]
-    fn rewrites_truthy_elif_and_else() {
-        let input = r#"
-if a:
-    pass
-elif b:
-    pass
-else:
-    pass
-"#;
-        let expected = r#"
-if __dp__.truth(a):
-    pass
-elif __dp__.truth(b):
-    pass
-else:
-    pass
-"#;
-        assert_transform_eq_truthy(input, expected);
-    }
-
-    #[test]
-    fn rewrites_truthy_while_condition() {
-        let input = r#"
-while a:
-    pass
-"#;
-        let expected = r#"
-while __dp__.truth(a):
-    pass
-"#;
-        assert_transform_eq_truthy(input, expected);
-    }
 }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod rewrite_for_loop;
 pub(crate) mod rewrite_import;
 pub(crate) mod rewrite_match_case;
 pub(crate) mod rewrite_string;
+pub(crate) mod rewrite_truthy;
 pub(crate) mod rewrite_try_except;
 pub(crate) mod rewrite_with;
 

--- a/src/transform/rewrite_truthy.rs
+++ b/src/transform/rewrite_truthy.rs
@@ -1,0 +1,124 @@
+use crate::body_transform::{walk_stmt, Transformer};
+use crate::py_expr;
+use ruff_python_ast::{self as ast, Expr, Stmt};
+
+pub(crate) fn rewrite(body: &mut Vec<Stmt>) {
+    let mut transformer = TruthyRewriter;
+    transformer.visit_body(body);
+}
+
+struct TruthyRewriter;
+
+impl Transformer for TruthyRewriter {
+    fn visit_stmt(&mut self, stmt: &mut Stmt) {
+        walk_stmt(self, stmt);
+
+        match stmt {
+            Stmt::If(ast::StmtIf {
+                test,
+                elif_else_clauses,
+                ..
+            }) => {
+                wrap_truthy_expr(test);
+                for clause in elif_else_clauses {
+                    if let Some(test) = &mut clause.test {
+                        wrap_truthy_expr(test);
+                    }
+                }
+            }
+            Stmt::While(ast::StmtWhile { test, .. }) => {
+                wrap_truthy_expr(test);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn wrap_truthy_expr(expr: &mut Expr) {
+    if is_truth_call(expr) {
+        return;
+    }
+
+    let original = expr.clone();
+    *expr = py_expr!(
+        "
+__dp__.truth({expr:expr})
+",
+        expr = original,
+    );
+}
+
+fn is_truth_call(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call(ast::ExprCall {
+            func, arguments, ..
+        }) if arguments.args.len() == 1 && arguments.keywords.is_empty() => match func.as_ref() {
+            Expr::Attribute(ast::ExprAttribute { value, attr, .. }) if attr.as_str() == "truth" => {
+                matches!(
+                    value.as_ref(),
+                    Expr::Name(ast::ExprName { id, .. }) if id.as_str() == "__dp__"
+                )
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_util::assert_transform_eq_truthy;
+
+    crate::transform_fixture_test!("tests_rewrite_truthy.txt");
+
+    #[test]
+    fn rewrites_truthy_if_condition() {
+        let input = r#"
+if a:
+    pass
+else:
+    pass
+"#;
+        let expected = r#"
+if __dp__.truth(a):
+    pass
+else:
+    pass
+"#;
+        assert_transform_eq_truthy(input, expected);
+    }
+
+    #[test]
+    fn rewrites_truthy_elif_and_else() {
+        let input = r#"
+if a:
+    pass
+elif b:
+    pass
+else:
+    pass
+"#;
+        let expected = r#"
+if __dp__.truth(a):
+    pass
+elif __dp__.truth(b):
+    pass
+else:
+    pass
+"#;
+        assert_transform_eq_truthy(input, expected);
+    }
+
+    #[test]
+    fn rewrites_truthy_while_condition() {
+        let input = r#"
+while a:
+    pass
+"#;
+        let expected = r#"
+while __dp__.truth(a):
+    pass
+"#;
+        assert_transform_eq_truthy(input, expected);
+    }
+}

--- a/src/transform/tests_rewrite_truthy.txt
+++ b/src/transform/tests_rewrite_truthy.txt
@@ -1,0 +1,13 @@
+$ truthy disabled if
+if a:
+    pass
+=
+if a:
+    pass
+
+$ truthy disabled while
+while a:
+    pass
+=
+while a:
+    pass


### PR DESCRIPTION
## Summary
- move truthiness wrapping into a dedicated `rewrite_truthy` module
- invoke the truthiness pass after other expression rewrites and expand coverage with targeted tests

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdae65b9f0832486ac7457ff15963f