### PR TITLE
Refactor statement rewriting work loop

### DIFF
--- a/src/transform/rewrite_import.rs
+++ b/src/transform/rewrite_import.rs
@@ -30,12 +30,14 @@ pub fn rewrite_from(
         ..
     }: ast::StmtImportFrom,
     options: &Options,
-) -> Option<Stmt> {
+) -> Stmt {
     if names.iter().any(|alias| alias.name.id.as_str() == "*") {
         return match options.import_star_handling {
-            ImportStarHandling::Allowed => None,
+            ImportStarHandling::Allowed => unreachable!(
+                "rewrite_from is only called when import-star rewriting is required"
+            ),
             ImportStarHandling::Error => panic!("import star not allowed"),
-            ImportStarHandling::Strip => Some(py_stmt!("{body:stmt}", body = Vec::new())),
+            ImportStarHandling::Strip => py_stmt!("{body:stmt}", body = Vec::new()),
         };
     }
     let module_name = module.as_ref().map(|n| n.id.as_str()).unwrap_or("");
@@ -64,7 +66,7 @@ pub fn rewrite_from(
         };
         stmts.push(assign);
     }
-    Some(py_stmt!("{body:stmt}", body = stmts))
+    py_stmt!("{body:stmt}", body = stmts)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a `Rewrite` enum and `ExprRewriter::rewrite_stmt` helper that returns batches of statements to visit or walk
- funnel both `visit_body` and `visit_stmt` through a shared `process_statements` worklist so buffered statements are scheduled without recursion
- guard `from`-import rewriting on the configured options and simplify `rewrite_from` to always return a statement now that allowed star imports bypass the helper

## Testing
- cargo test
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cdc0d995388324836719cef121c167