### PR TITLE
Refine maybe_placeholder temp handling

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -8,15 +8,14 @@ def add(a, b):
 add = _dp_dec_apply_1(add)
 def _dp_ns_A(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_2 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_2)
-    _dp_tmp_3 = "A"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_3)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_3)
-    _dp_tmp_4 = 1
-    __dp__.setitem(_dp_temp_ns, "b", _dp_tmp_4)
-    __dp__.setitem(_ns, "b", _dp_tmp_4)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_2 = "A"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
+    _dp_tmp_3 = 1
+    __dp__.setitem(_dp_temp_ns, "b", _dp_tmp_3)
+    __dp__.setitem(_ns, "b", _dp_tmp_3)
 
     def _dp_mk___init__():
 
@@ -24,9 +23,9 @@ def _dp_ns_A(_ns):
             __dp__.setattr(self, "arr", list((1, 2, 3)))
         __dp__.setattr(__init__, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".__init__"))
         return __init__
-    _dp_tmp_5 = _dp_mk___init__()
-    __dp__.setitem(_dp_temp_ns, "__init__", _dp_tmp_5)
-    __dp__.setitem(_ns, "__init__", _dp_tmp_5)
+    _dp_tmp_4 = _dp_mk___init__()
+    __dp__.setitem(_dp_temp_ns, "__init__", _dp_tmp_4)
+    __dp__.setitem(_ns, "__init__", _dp_tmp_4)
 
     def _dp_mk_c():
 
@@ -34,17 +33,17 @@ def _dp_ns_A(_ns):
             return add(d, 2)
         __dp__.setattr(c, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".c"))
         return c
-    _dp_tmp_6 = _dp_mk_c()
-    __dp__.setitem(_dp_temp_ns, "c", _dp_tmp_6)
-    __dp__.setitem(_ns, "c", _dp_tmp_6)
+    _dp_tmp_5 = _dp_mk_c()
+    __dp__.setitem(_dp_temp_ns, "c", _dp_tmp_5)
+    __dp__.setitem(_ns, "c", _dp_tmp_5)
 
     def _dp_mk_test_aiter():
 
         async def test_aiter(self):
-            _dp_iter_7 = __dp__.iter(range(10))
+            _dp_iter_6 = __dp__.iter(range(10))
             while True:
                 try:
-                    i = __dp__.next(_dp_iter_7)
+                    i = __dp__.next(_dp_iter_6)
                 except:
                     __dp__.check_stopiteration()
                     break
@@ -52,17 +51,17 @@ def _dp_ns_A(_ns):
                     yield i
         __dp__.setattr(test_aiter, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".test_aiter"))
         return test_aiter
-    _dp_tmp_8 = _dp_mk_test_aiter()
-    __dp__.setitem(_dp_temp_ns, "test_aiter", _dp_tmp_8)
-    __dp__.setitem(_ns, "test_aiter", _dp_tmp_8)
+    _dp_tmp_7 = _dp_mk_test_aiter()
+    __dp__.setitem(_dp_temp_ns, "test_aiter", _dp_tmp_7)
+    __dp__.setitem(_ns, "test_aiter", _dp_tmp_7)
 
     def _dp_mk_d():
 
         async def d(self):
-            _dp_iter_9 = __dp__.aiter(self.test_aiter())
+            _dp_iter_8 = __dp__.aiter(self.test_aiter())
             while True:
                 try:
-                    i = await __dp__.anext(_dp_iter_9)
+                    i = await __dp__.anext(_dp_iter_8)
                 except:
                     __dp__.acheck_stopiteration()
                     break
@@ -70,20 +69,20 @@ def _dp_ns_A(_ns):
                     print(i)
         __dp__.setattr(d, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".d"))
         return d
-    _dp_tmp_10 = _dp_mk_d()
-    __dp__.setitem(_dp_temp_ns, "d", _dp_tmp_10)
-    __dp__.setitem(_ns, "d", _dp_tmp_10)
+    _dp_tmp_9 = _dp_mk_d()
+    __dp__.setitem(_dp_temp_ns, "d", _dp_tmp_9)
+    __dp__.setitem(_ns, "d", _dp_tmp_9)
 def _dp_make_class_A():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_11 = __dp__.prepare_class("A", bases, None)
-    meta = __dp__.getitem(_dp_tmp_11, 0)
-    ns = __dp__.getitem(_dp_tmp_11, 1)
-    kwds = __dp__.getitem(_dp_tmp_11, 2)
+    _dp_tmp_10 = __dp__.prepare_class("A", bases, None)
+    meta = __dp__.getitem(_dp_tmp_10, 0)
+    ns = __dp__.getitem(_dp_tmp_10, 1)
+    kwds = __dp__.getitem(_dp_tmp_10, 2)
     _dp_ns_A(ns)
     return meta("A", bases, ns, **kwds)
-_dp_tmp_12 = _dp_make_class_A()
-A = _dp_tmp_12
-_dp_class_A = _dp_tmp_12
+_dp_tmp_11 = _dp_make_class_A()
+A = _dp_tmp_11
+_dp_class_A = _dp_tmp_11
 def ff():
     a = A()
     __dp__.setattr(a, "b", 5)
@@ -93,42 +92,42 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
-def _dp_gen_13(_dp_iter_14):
-    _dp_iter_15 = __dp__.iter(_dp_iter_14)
+def _dp_gen_12(_dp_iter_13):
+    _dp_iter_14 = __dp__.iter(_dp_iter_13)
     while True:
         try:
-            i = __dp__.next(_dp_iter_15)
+            i = __dp__.next(_dp_iter_14)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_16 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_16:
+            _dp_tmp_15 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_15:
                 yield __dp__.add(i, 1)
-x = list(_dp_gen_13(__dp__.iter(range(5))))
-def _dp_gen_17(_dp_iter_18):
-    _dp_iter_19 = __dp__.iter(_dp_iter_18)
+x = list(_dp_gen_12(__dp__.iter(range(5))))
+def _dp_gen_16(_dp_iter_17):
+    _dp_iter_18 = __dp__.iter(_dp_iter_17)
     while True:
         try:
-            i = __dp__.next(_dp_iter_19)
+            i = __dp__.next(_dp_iter_18)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_20 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_20:
+            _dp_tmp_19 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_19:
                 yield __dp__.add(i, 1)
-y = set(_dp_gen_17(__dp__.iter(range(5))))
-def _dp_gen_21(_dp_iter_22):
-    _dp_iter_23 = __dp__.iter(_dp_iter_22)
+y = set(_dp_gen_16(__dp__.iter(range(5))))
+def _dp_gen_20(_dp_iter_21):
+    _dp_iter_22 = __dp__.iter(_dp_iter_21)
     while True:
         try:
-            i = __dp__.next(_dp_iter_23)
+            i = __dp__.next(_dp_iter_22)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_24 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_24:
+            _dp_tmp_23 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_23:
                 yield __dp__.add(i, 1)
-z = _dp_gen_21(__dp__.iter(range(5)))
+z = _dp_gen_20(__dp__.iter(range(5)))

--- a/src/transform/rewrite_import.rs
+++ b/src/transform/rewrite_import.rs
@@ -33,9 +33,9 @@ pub fn rewrite_from(
 ) -> Stmt {
     if names.iter().any(|alias| alias.name.id.as_str() == "*") {
         return match options.import_star_handling {
-            ImportStarHandling::Allowed => unreachable!(
-                "rewrite_from is only called when import-star rewriting is required"
-            ),
+            ImportStarHandling::Allowed => {
+                unreachable!("rewrite_from is only called when import-star rewriting is required")
+            }
             ImportStarHandling::Error => panic!("import star not allowed"),
             ImportStarHandling::Strip => py_stmt!("{body:stmt}", body = Vec::new()),
         };

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -146,9 +146,8 @@ $ expr 021
 a = b = c
 =
 
-_dp_tmp_1 = c
-a = _dp_tmp_1
-b = _dp_tmp_1
+a = c
+b = c
 
 
 $ expr 022

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -34,12 +34,11 @@ class Foo:
 =
 def _dp_ns_Foo(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "Foo"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "Foo"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
 
     def _dp_mk_method():
 
@@ -47,17 +46,17 @@ def _dp_ns_Foo(_ns):
             return 1
         __dp__.setattr(method, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".method"))
         return method
-    _dp_tmp_3 = _dp_mk_method()
-    __dp__.setitem(_dp_temp_ns, "method", _dp_tmp_3)
-    __dp__.setitem(_ns, "method", _dp_tmp_3)
+    _dp_tmp_2 = _dp_mk_method()
+    __dp__.setitem(_dp_temp_ns, "method", _dp_tmp_2)
+    __dp__.setitem(_ns, "method", _dp_tmp_2)
 def _dp_make_class_Foo():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_4 = __dp__.prepare_class("Foo", bases, None)
-    meta = __dp__.getitem(_dp_tmp_4, 0)
-    ns = __dp__.getitem(_dp_tmp_4, 1)
-    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_tmp_3 = __dp__.prepare_class("Foo", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_Foo(ns)
     return meta("Foo", bases, ns, **kwds)
-_dp_tmp_5 = _dp_make_class_Foo()
-Foo = _dp_tmp_5
-_dp_class_Foo = _dp_tmp_5
+_dp_tmp_4 = _dp_make_class_Foo()
+Foo = _dp_tmp_4
+_dp_class_Foo = _dp_tmp_4

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -5,43 +5,16 @@ class C:
 =
 def _dp_ns_C(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
-    _dp_tmp_3 = 1
-    __dp__.setitem(_dp_temp_ns, "x", _dp_tmp_3)
-    __dp__.setitem(_ns, "x", _dp_tmp_3)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = 1
+    __dp__.setitem(_dp_temp_ns, "x", _dp_tmp_2)
+    __dp__.setitem(_ns, "x", _dp_tmp_2)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_4, 0)
-    ns = __dp__.getitem(_dp_tmp_4, 1)
-    kwds = __dp__.getitem(_dp_tmp_4, 2)
-    _dp_ns_C(ns)
-    return meta("C", bases, ns, **kwds)
-_dp_tmp_5 = _dp_make_class_C()
-C = _dp_tmp_5
-_dp_class_C = _dp_tmp_5
-
-$ lowers inherits
-
-class C(B):
-    pass
-=
-def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
-    pass
-def _dp_make_class_C():
-    bases = __dp__.resolve_bases((B,))
     _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_3, 0)
     ns = __dp__.getitem(_dp_tmp_3, 1)
@@ -52,6 +25,31 @@ _dp_tmp_4 = _dp_make_class_C()
 C = _dp_tmp_4
 _dp_class_C = _dp_tmp_4
 
+$ lowers inherits
+
+class C(B):
+    pass
+=
+def _dp_ns_C(_ns):
+    _dp_temp_ns = dict(())
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
+    pass
+def _dp_make_class_C():
+    bases = __dp__.resolve_bases((B,))
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_ns_C(ns)
+    return meta("C", bases, ns, **kwds)
+_dp_tmp_3 = _dp_make_class_C()
+C = _dp_tmp_3
+_dp_class_C = _dp_tmp_3
+
 $ lowers with docstring and keywords
 
 class C(B, metaclass=Meta, kw=1):
@@ -60,29 +58,28 @@ class C(B, metaclass=Meta, kw=1):
 =
 def _dp_ns_C(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
-    _dp_tmp_3 = 'doc'
-    __dp__.setitem(_dp_temp_ns, "__doc__", _dp_tmp_3)
-    __dp__.setitem(_ns, "__doc__", _dp_tmp_3)
-    _dp_tmp_4 = 2
-    __dp__.setitem(_dp_temp_ns, "x", _dp_tmp_4)
-    __dp__.setitem(_ns, "x", _dp_tmp_4)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = 'doc'
+    __dp__.setitem(_dp_temp_ns, "__doc__", _dp_tmp_2)
+    __dp__.setitem(_ns, "__doc__", _dp_tmp_2)
+    _dp_tmp_3 = 2
+    __dp__.setitem(_dp_temp_ns, "x", _dp_tmp_3)
+    __dp__.setitem(_ns, "x", _dp_tmp_3)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases((B,))
-    _dp_tmp_5 = __dp__.prepare_class("C", bases, dict((("metaclass", Meta), ("kw", 1))))
-    meta = __dp__.getitem(_dp_tmp_5, 0)
-    ns = __dp__.getitem(_dp_tmp_5, 1)
-    kwds = __dp__.getitem(_dp_tmp_5, 2)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, dict((("metaclass", Meta), ("kw", 1))))
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_6 = _dp_make_class_C()
-C = _dp_tmp_6
-_dp_class_C = _dp_tmp_6
+_dp_tmp_5 = _dp_make_class_C()
+C = _dp_tmp_5
+_dp_class_C = _dp_tmp_5
 
 $ lowers method
 
@@ -92,12 +89,11 @@ class C:
 =
 def _dp_ns_C(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
 
     def _dp_mk_m():
 
@@ -105,20 +101,20 @@ def _dp_ns_C(_ns):
             return 1
         __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".m"))
         return m
-    _dp_tmp_3 = _dp_mk_m()
-    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_3)
-    __dp__.setitem(_ns, "m", _dp_tmp_3)
+    _dp_tmp_2 = _dp_mk_m()
+    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_2)
+    __dp__.setitem(_ns, "m", _dp_tmp_2)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_4, 0)
-    ns = __dp__.getitem(_dp_tmp_4, 1)
-    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_5 = _dp_make_class_C()
-C = _dp_tmp_5
-_dp_class_C = _dp_tmp_5
+_dp_tmp_4 = _dp_make_class_C()
+C = _dp_tmp_4
+_dp_class_C = _dp_tmp_4
 
 $ rewrites super and class
 
@@ -128,12 +124,11 @@ class C:
 =
 def _dp_ns_C(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
 
     def _dp_mk_m():
 
@@ -142,20 +137,20 @@ def _dp_ns_C(_ns):
             return super(self, __class__).m()
         __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".m"))
         return m
-    _dp_tmp_3 = _dp_mk_m()
-    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_3)
-    __dp__.setitem(_ns, "m", _dp_tmp_3)
+    _dp_tmp_2 = _dp_mk_m()
+    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_2)
+    __dp__.setitem(_ns, "m", _dp_tmp_2)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_4, 0)
-    ns = __dp__.getitem(_dp_tmp_4, 1)
-    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_5 = _dp_make_class_C()
-C = _dp_tmp_5
-_dp_class_C = _dp_tmp_5
+_dp_tmp_4 = _dp_make_class_C()
+C = _dp_tmp_4
+_dp_class_C = _dp_tmp_4
 
 $ rewrites super uses first arg
 
@@ -165,12 +160,11 @@ class C:
 =
 def _dp_ns_C(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
 
     def _dp_mk_m():
 
@@ -179,17 +173,17 @@ def _dp_ns_C(_ns):
             return super(z, __class__).m()
         __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".m"))
         return m
-    _dp_tmp_3 = _dp_mk_m()
-    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_3)
-    __dp__.setitem(_ns, "m", _dp_tmp_3)
+    _dp_tmp_2 = _dp_mk_m()
+    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_2)
+    __dp__.setitem(_ns, "m", _dp_tmp_2)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_4, 0)
-    ns = __dp__.getitem(_dp_tmp_4, 1)
-    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_5 = _dp_make_class_C()
-C = _dp_tmp_5
-_dp_class_C = _dp_tmp_5
+_dp_tmp_4 = _dp_make_class_C()
+C = _dp_tmp_4
+_dp_class_C = _dp_tmp_4

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -21,19 +21,18 @@ def _dp_class_decorators_C(_dp_the_func):
     return dec(_dp_the_func)
 def _dp_ns_C(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
     pass
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -50,19 +49,18 @@ def _dp_class_decorators_C(_dp_the_func):
     return dec2(5)(dec1(_dp_the_func))
 def _dp_ns_C(_ns):
     _dp_temp_ns = dict(())
-    _dp_tmp_1 = __name__
-    __dp__.setitem(_dp_temp_ns, "__module__", _dp_tmp_1)
-    __dp__.setitem(_ns, "__module__", _dp_tmp_1)
-    _dp_tmp_2 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
-    __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
     pass
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()


### PR DESCRIPTION
## Summary
- refine `ExprRewriter::maybe_placeholder` to visit expressions and buffer temp assignments, removing redundant placeholder tracking
- simplify assignment, unpacking, and named expression rewrites to rely on `maybe_placeholder` without manual temp statements

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdeb6699f0832482c5c8fd56b3dab4