### PR TITLE
Change default import star handling to allow import star statements

### DIFF
--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -32,7 +32,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            import_star_handling: ImportStarHandling::Strip,
+            import_star_handling: ImportStarHandling::Allowed,
             inject_import: true,
             lower_attributes: true,
             truthy: false,


### PR DESCRIPTION
## Summary
- change the default transform options to allow `from ... import *` statements instead of stripping them

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce13fd9be083249198c4795d4b696b