### PR TITLE
Add transform timing instrumentation and CLI timing option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,39 @@
 use std::{env, fs, process};
 
-use diet_python::transform_to_string_without_attribute_lowering;
+use diet_python::transform_to_string_without_attribute_lowering_with_timing;
+
+const USAGE: &str = "usage: diet-python [--timing] <python-file>";
 
 fn main() {
-    let path = env::args().nth(1).unwrap_or_else(|| {
-        eprintln!("usage: diet-python <python-file>");
+    let mut timing = false;
+    let mut path: Option<String> = None;
+
+    for arg in env::args().skip(1) {
+        match arg.as_str() {
+            "--timing" => timing = true,
+            "--help" | "-h" => {
+                eprintln!("{}", USAGE);
+                return;
+            }
+            _ if arg.starts_with('-') => {
+                eprintln!("unknown option: {}", arg);
+                eprintln!("{}", USAGE);
+                process::exit(1);
+            }
+            _ => {
+                if path.is_none() {
+                    path = Some(arg);
+                } else {
+                    eprintln!("unexpected argument: {}", arg);
+                    eprintln!("{}", USAGE);
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    let path = path.unwrap_or_else(|| {
+        eprintln!("{}", USAGE);
         process::exit(1);
     });
 
@@ -16,12 +45,24 @@ fn main() {
         }
     };
 
-    let output = match transform_to_string_without_attribute_lowering(&source, true) {
-        Ok(output) => output,
-        Err(err) => {
-            eprintln!("failed to parse {}: {}", path, err);
-            process::exit(1);
-        }
-    };
+    let (output, timings) =
+        match transform_to_string_without_attribute_lowering_with_timing(&source, true) {
+            Ok(result) => result,
+            Err(err) => {
+                eprintln!("failed to parse {}: {}", path, err);
+                process::exit(1);
+            }
+        };
     print!("{}", output);
+
+    if timing {
+        eprintln!(
+            "{{\"parse_ns\":{},\"rewrite_ns\":{},\"ensure_import_ns\":{},\"emit_ns\":{},\"total_ns\":{}}}",
+            timings.parse.as_nanos(),
+            timings.rewrite.as_nanos(),
+            timings.ensure_import.as_nanos(),
+            timings.emit.as_nanos(),
+            timings.total.as_nanos()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add `TransformTimings` struct and timed transform helpers to capture parse, rewrite, ensure-import, emit, and total durations
- expose new `transform_to_string*` and `transform_str_to_ruff*` variants that return timings, and surface them from the CLI via a new `--timing` flag
- extend the CLI argument parser to handle `--timing`/`--help` and emit JSON timing records to stderr while preserving existing behavior

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce0bc472a88324899f0feb46469bec