### PR TITLE
Skip temps for simple literals

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -13,9 +13,8 @@ def _dp_ns_A(_ns):
     _dp_tmp_2 = "A"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_2)
-    _dp_tmp_3 = 1
-    __dp__.setitem(_dp_temp_ns, "b", _dp_tmp_3)
-    __dp__.setitem(_ns, "b", _dp_tmp_3)
+    __dp__.setitem(_dp_temp_ns, "b", 1)
+    __dp__.setitem(_ns, "b", 1)
 
     def _dp_mk___init__():
 
@@ -23,9 +22,9 @@ def _dp_ns_A(_ns):
             __dp__.setattr(self, "arr", list((1, 2, 3)))
         __dp__.setattr(__init__, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".__init__"))
         return __init__
-    _dp_tmp_4 = _dp_mk___init__()
-    __dp__.setitem(_dp_temp_ns, "__init__", _dp_tmp_4)
-    __dp__.setitem(_ns, "__init__", _dp_tmp_4)
+    _dp_tmp_3 = _dp_mk___init__()
+    __dp__.setitem(_dp_temp_ns, "__init__", _dp_tmp_3)
+    __dp__.setitem(_ns, "__init__", _dp_tmp_3)
 
     def _dp_mk_c():
 
@@ -33,17 +32,17 @@ def _dp_ns_A(_ns):
             return add(d, 2)
         __dp__.setattr(c, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".c"))
         return c
-    _dp_tmp_5 = _dp_mk_c()
-    __dp__.setitem(_dp_temp_ns, "c", _dp_tmp_5)
-    __dp__.setitem(_ns, "c", _dp_tmp_5)
+    _dp_tmp_4 = _dp_mk_c()
+    __dp__.setitem(_dp_temp_ns, "c", _dp_tmp_4)
+    __dp__.setitem(_ns, "c", _dp_tmp_4)
 
     def _dp_mk_test_aiter():
 
         async def test_aiter(self):
-            _dp_iter_6 = __dp__.iter(range(10))
+            _dp_iter_5 = __dp__.iter(range(10))
             while True:
                 try:
-                    i = __dp__.next(_dp_iter_6)
+                    i = __dp__.next(_dp_iter_5)
                 except:
                     __dp__.check_stopiteration()
                     break
@@ -51,17 +50,17 @@ def _dp_ns_A(_ns):
                     yield i
         __dp__.setattr(test_aiter, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".test_aiter"))
         return test_aiter
-    _dp_tmp_7 = _dp_mk_test_aiter()
-    __dp__.setitem(_dp_temp_ns, "test_aiter", _dp_tmp_7)
-    __dp__.setitem(_ns, "test_aiter", _dp_tmp_7)
+    _dp_tmp_6 = _dp_mk_test_aiter()
+    __dp__.setitem(_dp_temp_ns, "test_aiter", _dp_tmp_6)
+    __dp__.setitem(_ns, "test_aiter", _dp_tmp_6)
 
     def _dp_mk_d():
 
         async def d(self):
-            _dp_iter_8 = __dp__.aiter(self.test_aiter())
+            _dp_iter_7 = __dp__.aiter(self.test_aiter())
             while True:
                 try:
-                    i = await __dp__.anext(_dp_iter_8)
+                    i = await __dp__.anext(_dp_iter_7)
                 except:
                     __dp__.acheck_stopiteration()
                     break
@@ -69,20 +68,20 @@ def _dp_ns_A(_ns):
                     print(i)
         __dp__.setattr(d, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".d"))
         return d
-    _dp_tmp_9 = _dp_mk_d()
-    __dp__.setitem(_dp_temp_ns, "d", _dp_tmp_9)
-    __dp__.setitem(_ns, "d", _dp_tmp_9)
+    _dp_tmp_8 = _dp_mk_d()
+    __dp__.setitem(_dp_temp_ns, "d", _dp_tmp_8)
+    __dp__.setitem(_ns, "d", _dp_tmp_8)
 def _dp_make_class_A():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_10 = __dp__.prepare_class("A", bases, None)
-    meta = __dp__.getitem(_dp_tmp_10, 0)
-    ns = __dp__.getitem(_dp_tmp_10, 1)
-    kwds = __dp__.getitem(_dp_tmp_10, 2)
+    _dp_tmp_9 = __dp__.prepare_class("A", bases, None)
+    meta = __dp__.getitem(_dp_tmp_9, 0)
+    ns = __dp__.getitem(_dp_tmp_9, 1)
+    kwds = __dp__.getitem(_dp_tmp_9, 2)
     _dp_ns_A(ns)
     return meta("A", bases, ns, **kwds)
-_dp_tmp_11 = _dp_make_class_A()
-A = _dp_tmp_11
-_dp_class_A = _dp_tmp_11
+_dp_tmp_10 = _dp_make_class_A()
+A = _dp_tmp_10
+_dp_class_A = _dp_tmp_10
 def ff():
     a = A()
     __dp__.setattr(a, "b", 5)
@@ -92,42 +91,42 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
-def _dp_gen_12(_dp_iter_13):
-    _dp_iter_14 = __dp__.iter(_dp_iter_13)
+def _dp_gen_11(_dp_iter_12):
+    _dp_iter_13 = __dp__.iter(_dp_iter_12)
     while True:
         try:
-            i = __dp__.next(_dp_iter_14)
+            i = __dp__.next(_dp_iter_13)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_15 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_15:
+            _dp_tmp_14 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_14:
                 yield __dp__.add(i, 1)
-x = list(_dp_gen_12(__dp__.iter(range(5))))
-def _dp_gen_16(_dp_iter_17):
-    _dp_iter_18 = __dp__.iter(_dp_iter_17)
+x = list(_dp_gen_11(__dp__.iter(range(5))))
+def _dp_gen_15(_dp_iter_16):
+    _dp_iter_17 = __dp__.iter(_dp_iter_16)
     while True:
         try:
-            i = __dp__.next(_dp_iter_18)
+            i = __dp__.next(_dp_iter_17)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_19 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_19:
+            _dp_tmp_18 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_18:
                 yield __dp__.add(i, 1)
-y = set(_dp_gen_16(__dp__.iter(range(5))))
-def _dp_gen_20(_dp_iter_21):
-    _dp_iter_22 = __dp__.iter(_dp_iter_21)
+y = set(_dp_gen_15(__dp__.iter(range(5))))
+def _dp_gen_19(_dp_iter_20):
+    _dp_iter_21 = __dp__.iter(_dp_iter_20)
     while True:
         try:
-            i = __dp__.next(_dp_iter_22)
+            i = __dp__.next(_dp_iter_21)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_23 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_23:
+            _dp_tmp_22 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_22:
                 yield __dp__.add(i, 1)
-z = _dp_gen_20(__dp__.iter(range(5)))
+z = _dp_gen_19(__dp__.iter(range(5)))

--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -6,7 +6,7 @@ use super::{
     rewrite_try_except, rewrite_with, ImportStarHandling, Options,
 };
 use crate::body_transform::{walk_expr, walk_stmt, Transformer};
-use crate::template::{make_binop, make_generator, make_tuple, make_unaryop};
+use crate::template::{is_simple, make_binop, make_generator, make_tuple, make_unaryop};
 use crate::{py_expr, py_stmt};
 use ruff_python_ast::{self as ast, Expr, Operator, Stmt, UnaryOp};
 use ruff_text_size::TextRange;
@@ -89,13 +89,17 @@ impl<'a> ExprRewriter<'a> {
     }
 
     pub(super) fn maybe_placeholder(&mut self, mut expr: Expr) -> Expr {
-        if matches!(expr, Expr::Name(_)) {
+        fn is_temp_skippable(expr: &Expr) -> bool {
+            is_simple(expr) && !matches!(expr, Expr::StringLiteral(_) | Expr::BytesLiteral(_))
+        }
+
+        if is_temp_skippable(&expr) {
             return expr;
         }
 
         self.visit_expr(&mut expr);
 
-        if matches!(expr, Expr::Name(_)) {
+        if is_temp_skippable(&expr) {
             return expr;
         }
 

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -154,9 +154,8 @@ $ expr 022
 a[0] = b = 1
 =
 
-_dp_tmp_1 = 1
-__dp__.setitem(a, 0, _dp_tmp_1)
-b = _dp_tmp_1
+__dp__.setitem(a, 0, 1)
+b = 1
 
 
 $ expr 023

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -10,20 +10,19 @@ def _dp_ns_C(_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
-    _dp_tmp_2 = 1
-    __dp__.setitem(_dp_temp_ns, "x", _dp_tmp_2)
-    __dp__.setitem(_ns, "x", _dp_tmp_2)
+    __dp__.setitem(_dp_temp_ns, "x", 1)
+    __dp__.setitem(_ns, "x", 1)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_4 = _dp_make_class_C()
-C = _dp_tmp_4
-_dp_class_C = _dp_tmp_4
+_dp_tmp_3 = _dp_make_class_C()
+C = _dp_tmp_3
+_dp_class_C = _dp_tmp_3
 
 $ lowers inherits
 
@@ -66,20 +65,19 @@ def _dp_ns_C(_ns):
     _dp_tmp_2 = 'doc'
     __dp__.setitem(_dp_temp_ns, "__doc__", _dp_tmp_2)
     __dp__.setitem(_ns, "__doc__", _dp_tmp_2)
-    _dp_tmp_3 = 2
-    __dp__.setitem(_dp_temp_ns, "x", _dp_tmp_3)
-    __dp__.setitem(_ns, "x", _dp_tmp_3)
+    __dp__.setitem(_dp_temp_ns, "x", 2)
+    __dp__.setitem(_ns, "x", 2)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases((B,))
-    _dp_tmp_4 = __dp__.prepare_class("C", bases, dict((("metaclass", Meta), ("kw", 1))))
-    meta = __dp__.getitem(_dp_tmp_4, 0)
-    ns = __dp__.getitem(_dp_tmp_4, 1)
-    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, dict((("metaclass", Meta), ("kw", 1))))
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_5 = _dp_make_class_C()
-C = _dp_tmp_5
-_dp_class_C = _dp_tmp_5
+_dp_tmp_4 = _dp_make_class_C()
+C = _dp_tmp_4
+_dp_class_C = _dp_tmp_4
 
 $ lowers method
 


### PR DESCRIPTION
## Summary
- avoid creating temporary placeholders in `maybe_placeholder` for simple literals other than strings/bytes
- update class rewriting and expression fixtures to reflect the new literal handling
- refresh the example desugared module with the adjusted output

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce33e177b8832498639cdeca714569