### PR TITLE
Evaluate class method decorators in namespace function

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -22,9 +22,9 @@ def _dp_ns_A(_ns):
             __dp__.setattr(self, "arr", list((1, 2, 3)))
         __dp__.setattr(__init__, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".__init__"))
         return __init__
-    _dp_tmp_3 = _dp_mk___init__()
-    __dp__.setitem(_dp_temp_ns, "__init__", _dp_tmp_3)
-    __dp__.setitem(_ns, "__init__", _dp_tmp_3)
+    __init__ = _dp_mk___init__()
+    __dp__.setitem(_dp_temp_ns, "__init__", __init__)
+    __dp__.setitem(_ns, "__init__", __init__)
 
     def _dp_mk_c():
 
@@ -32,17 +32,17 @@ def _dp_ns_A(_ns):
             return add(d, 2)
         __dp__.setattr(c, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".c"))
         return c
-    _dp_tmp_4 = _dp_mk_c()
-    __dp__.setitem(_dp_temp_ns, "c", _dp_tmp_4)
-    __dp__.setitem(_ns, "c", _dp_tmp_4)
+    c = _dp_mk_c()
+    __dp__.setitem(_dp_temp_ns, "c", c)
+    __dp__.setitem(_ns, "c", c)
 
     def _dp_mk_test_aiter():
 
         async def test_aiter(self):
-            _dp_iter_5 = __dp__.iter(range(10))
+            _dp_iter_3 = __dp__.iter(range(10))
             while True:
                 try:
-                    i = __dp__.next(_dp_iter_5)
+                    i = __dp__.next(_dp_iter_3)
                 except:
                     __dp__.check_stopiteration()
                     break
@@ -50,17 +50,17 @@ def _dp_ns_A(_ns):
                     yield i
         __dp__.setattr(test_aiter, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".test_aiter"))
         return test_aiter
-    _dp_tmp_6 = _dp_mk_test_aiter()
-    __dp__.setitem(_dp_temp_ns, "test_aiter", _dp_tmp_6)
-    __dp__.setitem(_ns, "test_aiter", _dp_tmp_6)
+    test_aiter = _dp_mk_test_aiter()
+    __dp__.setitem(_dp_temp_ns, "test_aiter", test_aiter)
+    __dp__.setitem(_ns, "test_aiter", test_aiter)
 
     def _dp_mk_d():
 
         async def d(self):
-            _dp_iter_7 = __dp__.aiter(self.test_aiter())
+            _dp_iter_4 = __dp__.aiter(self.test_aiter())
             while True:
                 try:
-                    i = await __dp__.anext(_dp_iter_7)
+                    i = await __dp__.anext(_dp_iter_4)
                 except:
                     __dp__.acheck_stopiteration()
                     break
@@ -68,20 +68,20 @@ def _dp_ns_A(_ns):
                     print(i)
         __dp__.setattr(d, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".d"))
         return d
-    _dp_tmp_8 = _dp_mk_d()
-    __dp__.setitem(_dp_temp_ns, "d", _dp_tmp_8)
-    __dp__.setitem(_ns, "d", _dp_tmp_8)
+    d = _dp_mk_d()
+    __dp__.setitem(_dp_temp_ns, "d", d)
+    __dp__.setitem(_ns, "d", d)
 def _dp_make_class_A():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_9 = __dp__.prepare_class("A", bases, None)
-    meta = __dp__.getitem(_dp_tmp_9, 0)
-    ns = __dp__.getitem(_dp_tmp_9, 1)
-    kwds = __dp__.getitem(_dp_tmp_9, 2)
+    _dp_tmp_5 = __dp__.prepare_class("A", bases, None)
+    meta = __dp__.getitem(_dp_tmp_5, 0)
+    ns = __dp__.getitem(_dp_tmp_5, 1)
+    kwds = __dp__.getitem(_dp_tmp_5, 2)
     _dp_ns_A(ns)
     return meta("A", bases, ns, **kwds)
-_dp_tmp_10 = _dp_make_class_A()
-A = _dp_tmp_10
-_dp_class_A = _dp_tmp_10
+_dp_tmp_6 = _dp_make_class_A()
+A = _dp_tmp_6
+_dp_class_A = _dp_tmp_6
 def ff():
     a = A()
     __dp__.setattr(a, "b", 5)
@@ -91,6 +91,19 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
+def _dp_gen_7(_dp_iter_8):
+    _dp_iter_9 = __dp__.iter(_dp_iter_8)
+    while True:
+        try:
+            i = __dp__.next(_dp_iter_9)
+        except:
+            __dp__.check_stopiteration()
+            break
+        else:
+            _dp_tmp_10 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_10:
+                yield __dp__.add(i, 1)
+x = list(_dp_gen_7(__dp__.iter(range(5))))
 def _dp_gen_11(_dp_iter_12):
     _dp_iter_13 = __dp__.iter(_dp_iter_12)
     while True:
@@ -103,7 +116,7 @@ def _dp_gen_11(_dp_iter_12):
             _dp_tmp_14 = __dp__.eq(__dp__.mod(i, 2), 0)
             if _dp_tmp_14:
                 yield __dp__.add(i, 1)
-x = list(_dp_gen_11(__dp__.iter(range(5))))
+y = set(_dp_gen_11(__dp__.iter(range(5))))
 def _dp_gen_15(_dp_iter_16):
     _dp_iter_17 = __dp__.iter(_dp_iter_16)
     while True:
@@ -116,17 +129,4 @@ def _dp_gen_15(_dp_iter_16):
             _dp_tmp_18 = __dp__.eq(__dp__.mod(i, 2), 0)
             if _dp_tmp_18:
                 yield __dp__.add(i, 1)
-y = set(_dp_gen_15(__dp__.iter(range(5))))
-def _dp_gen_19(_dp_iter_20):
-    _dp_iter_21 = __dp__.iter(_dp_iter_20)
-    while True:
-        try:
-            i = __dp__.next(_dp_iter_21)
-        except:
-            __dp__.check_stopiteration()
-            break
-        else:
-            _dp_tmp_22 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_22:
-                yield __dp__.add(i, 1)
-z = _dp_gen_19(__dp__.iter(range(5)))
+z = _dp_gen_15(__dp__.iter(range(5)))

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -46,17 +46,17 @@ def _dp_ns_Foo(_ns):
             return 1
         __dp__.setattr(method, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".method"))
         return method
-    _dp_tmp_2 = _dp_mk_method()
-    __dp__.setitem(_dp_temp_ns, "method", _dp_tmp_2)
-    __dp__.setitem(_ns, "method", _dp_tmp_2)
+    method = _dp_mk_method()
+    __dp__.setitem(_dp_temp_ns, "method", method)
+    __dp__.setitem(_ns, "method", method)
 def _dp_make_class_Foo():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_3 = __dp__.prepare_class("Foo", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_2 = __dp__.prepare_class("Foo", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_Foo(ns)
     return meta("Foo", bases, ns, **kwds)
-_dp_tmp_4 = _dp_make_class_Foo()
-Foo = _dp_tmp_4
-_dp_class_Foo = _dp_tmp_4
+_dp_tmp_3 = _dp_make_class_Foo()
+Foo = _dp_tmp_3
+_dp_class_Foo = _dp_tmp_3

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -99,20 +99,20 @@ def _dp_ns_C(_ns):
             return 1
         __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".m"))
         return m
-    _dp_tmp_2 = _dp_mk_m()
-    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_2)
-    __dp__.setitem(_ns, "m", _dp_tmp_2)
+    m = _dp_mk_m()
+    __dp__.setitem(_dp_temp_ns, "m", m)
+    __dp__.setitem(_ns, "m", m)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_4 = _dp_make_class_C()
-C = _dp_tmp_4
-_dp_class_C = _dp_tmp_4
+_dp_tmp_3 = _dp_make_class_C()
+C = _dp_tmp_3
+_dp_class_C = _dp_tmp_3
 
 $ rewrites super and class
 
@@ -135,20 +135,20 @@ def _dp_ns_C(_ns):
             return super(self, __class__).m()
         __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".m"))
         return m
-    _dp_tmp_2 = _dp_mk_m()
-    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_2)
-    __dp__.setitem(_ns, "m", _dp_tmp_2)
+    m = _dp_mk_m()
+    __dp__.setitem(_dp_temp_ns, "m", m)
+    __dp__.setitem(_ns, "m", m)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_4 = _dp_make_class_C()
-C = _dp_tmp_4
-_dp_class_C = _dp_tmp_4
+_dp_tmp_3 = _dp_make_class_C()
+C = _dp_tmp_3
+_dp_class_C = _dp_tmp_3
 
 $ rewrites super uses first arg
 
@@ -171,17 +171,62 @@ def _dp_ns_C(_ns):
             return super(z, __class__).m()
         __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".m"))
         return m
-    _dp_tmp_2 = _dp_mk_m()
-    __dp__.setitem(_dp_temp_ns, "m", _dp_tmp_2)
-    __dp__.setitem(_ns, "m", _dp_tmp_2)
+    m = _dp_mk_m()
+    __dp__.setitem(_dp_temp_ns, "m", m)
+    __dp__.setitem(_ns, "m", m)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases(())
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_4 = _dp_make_class_C()
-C = _dp_tmp_4
-_dp_class_C = _dp_tmp_4
+_dp_tmp_3 = _dp_make_class_C()
+C = _dp_tmp_3
+_dp_class_C = _dp_tmp_3
+
+$ applies decorators in namespace
+
+class C:
+    y = deco
+
+    @decorator(y)
+    @other
+    def m(self):
+        return self
+=
+def _dp_ns_C(_ns):
+    _dp_temp_ns = dict(())
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_dp_temp_ns, "y", deco)
+    __dp__.setitem(_ns, "y", deco)
+    _dp_dec_m_0 = decorator(y)
+    _dp_dec_m_1 = other
+
+    def _dp_mk_m():
+
+        def m(self):
+            return self
+        __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".m"))
+        return m
+    m = _dp_mk_m()
+    m = _dp_dec_m_1(m)
+    m = _dp_dec_m_0(m)
+    __dp__.setitem(_dp_temp_ns, "m", m)
+    __dp__.setitem(_ns, "m", m)
+def _dp_make_class_C():
+    bases = __dp__.resolve_bases(())
+    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_2, 0)
+    ns = __dp__.getitem(_dp_tmp_2, 1)
+    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_ns_C(ns)
+    return meta("C", bases, ns, **kwds)
+_dp_tmp_3 = _dp_make_class_C()
+C = _dp_tmp_3
+_dp_class_C = _dp_tmp_3


### PR DESCRIPTION
## Summary
- evaluate method decorators inside the class namespace builder so they see previously established bindings
- apply the evaluated decorators after calling the generated `_dp_mk_*` helper while preserving the local method binding
- extend the class rewrite fixture to cover decorated methods

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cec507131483249e09ee6d5f78e014