### PR TITLE
Reference builtins via __dp__

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -54,6 +54,10 @@ aiter = builtins.aiter
 anext = builtins.anext
 isinstance = builtins.isinstance
 setattr = builtins.setattr
+tuple = builtins.tuple
+list = builtins.list
+dict = builtins.dict
+set = builtins.set
 
 def resolve_bases(bases):
     return _types.resolve_bases(bases)

--- a/example_desugar.py
+++ b/example_desugar.py
@@ -1,13 +1,13 @@
 import __dp__
 sys = __dp__.import_("sys", __spec__)
-ei = __dp__.import_("sys", __spec__, list(("exc_info",))).exc_info
+ei = __dp__.import_("sys", __spec__, __dp__.list(("exc_info",))).exc_info
 def _dp_dec_apply_1(_dp_the_func):
     return foo(bar(1, 2)(_dp_the_func))
 def add(a, b):
     return __dp__.add(a, b)
 add = _dp_dec_apply_1(add)
 def _dp_ns_A(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_2 = "A"
@@ -20,7 +20,7 @@ def _dp_ns_A(_ns):
     def _dp_mk___init__():
 
         def __init__(self):
-            __dp__.setattr(self, "arr", list((1, 2, 3)))
+            __dp__.setattr(self, "arr", __dp__.list((1, 2, 3)))
         __dp__.setattr(__init__, "__qualname__", __dp__.add(__dp__.getitem(_ns, "__qualname__"), ".__init__"))
         return __init__
     __init__ = _dp_mk___init__()
@@ -104,7 +104,7 @@ def _dp_gen_7(_dp_iter_8):
             _dp_tmp_10 = __dp__.eq(__dp__.mod(i, 2), 0)
             if _dp_tmp_10:
                 yield __dp__.add(i, 1)
-x = list(_dp_gen_7(__dp__.iter(range(5))))
+x = __dp__.list(_dp_gen_7(__dp__.iter(range(5))))
 def _dp_gen_11(_dp_iter_12):
     _dp_iter_13 = __dp__.iter(_dp_iter_12)
     while True:
@@ -117,7 +117,7 @@ def _dp_gen_11(_dp_iter_12):
             _dp_tmp_14 = __dp__.eq(__dp__.mod(i, 2), 0)
             if _dp_tmp_14:
                 yield __dp__.add(i, 1)
-y = set(_dp_gen_11(__dp__.iter(range(5))))
+y = __dp__.set(_dp_gen_11(__dp__.iter(range(5))))
 def _dp_gen_15(_dp_iter_16):
     _dp_iter_17 = __dp__.iter(_dp_iter_16)
     while True:

--- a/src/transform/expr.rs
+++ b/src/transform/expr.rs
@@ -200,7 +200,7 @@ fn make_tuple_splat(tuple: ast::ExprTuple) -> Expr {
                 if !values.is_empty() {
                     segments.push(make_tuple(std::mem::take(&mut values)));
                 }
-                segments.push(py_expr!("tuple({value:expr})", value = *value));
+                segments.push(py_expr!("__dp__.tuple({value:expr})", value = *value));
             }
             other => values.push(other),
         }
@@ -341,10 +341,10 @@ impl<'a> Transformer for ExprRewriter<'a> {
             }
             Expr::ListComp(ast::ExprListComp {
                 elt, generators, ..
-            }) => py_expr!("list({expr:expr})", expr = make_generator(*elt, generators)),
+            }) => py_expr!("__dp__.list({expr:expr})", expr = make_generator(*elt, generators)),
             Expr::SetComp(ast::ExprSetComp {
                 elt, generators, ..
-            }) => py_expr!("set({expr:expr})", expr = make_generator(*elt, generators)),
+            }) => py_expr!("__dp__.set({expr:expr})", expr = make_generator(*elt, generators)),
             Expr::DictComp(ast::ExprDictComp {
                 key,
                 value,
@@ -353,7 +353,7 @@ impl<'a> Transformer for ExprRewriter<'a> {
             }) => {
                 let tuple = py_expr!("({key:expr}, {value:expr})", key = *key, value = *value,);
                 py_expr!(
-                    "dict({expr:expr})",
+                    "__dp__.dict({expr:expr})",
                     expr = make_generator(tuple, generators)
                 )
             }
@@ -365,11 +365,11 @@ impl<'a> Transformer for ExprRewriter<'a> {
                     ctx: ast::ExprContext::Load,
                     parenthesized: false,
                 });
-                py_expr!("list({tuple:expr})", tuple = tuple,)
+                py_expr!("__dp__.list({tuple:expr})", tuple = tuple,)
             }
             Expr::Set(ast::ExprSet { elts, .. }) => {
                 let tuple = make_tuple(elts);
-                py_expr!("set({tuple:expr})", tuple = tuple,)
+                py_expr!("__dp__.set({tuple:expr})", tuple = tuple,)
             }
             Expr::Dict(ast::ExprDict { items, .. }) => {
                 let mut iter = items.into_iter().peekable();
@@ -390,7 +390,7 @@ impl<'a> Transformer for ExprRewriter<'a> {
 
                     if !keyed_pairs.is_empty() {
                         let tuple = make_tuple(keyed_pairs);
-                        segments.push(py_expr!("dict({tuple:expr})", tuple = tuple));
+                        segments.push(py_expr!("__dp__.dict({tuple:expr})", tuple = tuple));
                     }
 
                     let Some(item) = iter.next() else {
@@ -401,16 +401,16 @@ impl<'a> Transformer for ExprRewriter<'a> {
                         let pair =
                             py_expr!("({key:expr}, {value:expr})", key = key, value = item.value,);
                         let tuple = make_tuple(vec![pair]);
-                        segments.push(py_expr!("dict({tuple:expr})", tuple = tuple));
+                        segments.push(py_expr!("__dp__.dict({tuple:expr})", tuple = tuple));
                     } else {
-                        segments.push(py_expr!("dict({mapping:expr})", mapping = item.value));
+                        segments.push(py_expr!("__dp__.dict({mapping:expr})", mapping = item.value));
                     }
                 }
 
                 match segments.len() {
                     0 => {
                         let tuple = make_tuple(Vec::new());
-                        py_expr!("dict({tuple:expr})", tuple = tuple)
+                        py_expr!("__dp__.dict({tuple:expr})", tuple = tuple)
                     }
                     1 => segments.into_iter().next().unwrap(),
                     _ => {

--- a/src/transform/rewrite_assign_del.rs
+++ b/src/transform/rewrite_assign_del.rs
@@ -107,10 +107,10 @@ fn rewrite_unpack_target(
                 };
                 let collection_expr = match kind {
                     UnpackTargetKind::Tuple => {
-                        py_expr!("tuple({slice:expr})", slice = slice_expr)
+                        py_expr!("__dp__.tuple({slice:expr})", slice = slice_expr)
                     }
                     UnpackTargetKind::List => {
-                        py_expr!("list({slice:expr})", slice = slice_expr)
+                        py_expr!("__dp__.list({slice:expr})", slice = slice_expr)
                     }
                 };
                 rewrite_target(rewriter, *value, collection_expr, out);

--- a/src/transform/rewrite_match_case.rs
+++ b/src/transform/rewrite_match_case.rs
@@ -170,7 +170,7 @@ else:
                                 start = start_expr,
                                 end = end_expr
                             );
-                            let list_expr = py_expr!("list({value:expr})", value = slice_expr);
+                            let list_expr = py_expr!("__dp__.list({value:expr})", value = slice_expr);
                             assigns.push(py_stmt!(
                                 "{name:id} = {value:expr}",
                                 name = name.as_str(),
@@ -286,7 +286,7 @@ else:
 
             if let Some(name) = rest {
                 assigns.push(py_stmt!(
-                    "{name:id} = dict({subject:expr})",
+                    "{name:id} = __dp__.dict({subject:expr})",
                     name = name.as_str(),
                     subject = subject.clone()
                 ));
@@ -323,7 +323,7 @@ else:
             let expr = fold_exprs(tests, ast::BoolOp::And);
             let mut assigns = Vec::new();
             if let Some(name) = name {
-                let list_expr = py_expr!("list({subject:expr})", subject = subject.clone());
+                let list_expr = py_expr!("__dp__.list({subject:expr})", subject = subject.clone());
                 assigns.push(py_stmt!(
                     "{name:id} = {value:expr}",
                     name = name.as_str(),

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -3,7 +3,7 @@ $ expr 001
 =
 
 a = __dp__.getitem(d, 0)
-b = list(__dp__.getitem(d, slice(1, __dp__.neg(1), None)))
+b = __dp__.list(__dp__.getitem(d, slice(1, __dp__.neg(1), None)))
 c = __dp__.getitem(d, __dp__.neg(1))
 
 
@@ -12,7 +12,7 @@ $ expr 002
 =
 
 a = __dp__.getitem(c, 0)
-b = list(__dp__.getitem(c, slice(1, None, None)))
+b = __dp__.list(__dp__.getitem(c, slice(1, None, None)))
 
 
 $ expr 003
@@ -27,7 +27,7 @@ $ expr 004
 [*a, b] = c
 =
 
-a = list(__dp__.getitem(c, slice(0, __dp__.neg(1), None)))
+a = __dp__.list(__dp__.getitem(c, slice(0, __dp__.neg(1), None)))
 b = __dp__.getitem(c, __dp__.neg(1))
 
 
@@ -44,7 +44,7 @@ a, *b, c = d
 =
 
 a = __dp__.getitem(d, 0)
-b = tuple(__dp__.getitem(d, slice(1, __dp__.neg(1), None)))
+b = __dp__.tuple(__dp__.getitem(d, slice(1, __dp__.neg(1), None)))
 c = __dp__.getitem(d, __dp__.neg(1))
 
 
@@ -52,7 +52,7 @@ $ expr 007
 *a, b = c
 =
 
-a = tuple(__dp__.getitem(c, slice(0, __dp__.neg(1), None)))
+a = __dp__.tuple(__dp__.getitem(c, slice(0, __dp__.neg(1), None)))
 b = __dp__.getitem(c, __dp__.neg(1))
 
 
@@ -61,7 +61,7 @@ a, *b = c
 =
 
 a = __dp__.getitem(c, 0)
-b = tuple(__dp__.getitem(c, slice(1, None, None)))
+b = __dp__.tuple(__dp__.getitem(c, slice(1, None, None)))
 
 
 $ expr 009
@@ -313,14 +313,14 @@ def _dp_gen_1(items):
             _dp_tmp_4 = __dp__.eq(__dp__.mod(k, 2), 0)
             if _dp_tmp_4:
                 yield k, __dp__.add(v, 1)
-r = dict(_dp_gen_1(__dp__.iter(items)))
+r = __dp__.dict(_dp_gen_1(__dp__.iter(items)))
 
 
 $ expr 042
 a = {'a': 1, 'b': 2}
 =
 
-a = dict((('a', 1), ('b', 2)))
+a = __dp__.dict((('a', 1), ('b', 2)))
 
 
 $ expr 043
@@ -334,17 +334,17 @@ _dp_tmp_1
 $ expr 044
 a = {**b, 'c': 2}
 =
-a = __dp__.or_(dict(b), dict((('c', 2),)))
+a = __dp__.or_(__dp__.dict(b), __dp__.dict((('c', 2),)))
 
 $ expr 045
 a = {**b}
 =
-a = dict(b)
+a = __dp__.dict(b)
 
 $ expr 046
 a = {'a': 1, **b, 'c': 2}
 =
-a = __dp__.or_(__dp__.or_(dict((('a', 1),)), dict(b)), dict((('c', 2),)))
+a = __dp__.or_(__dp__.or_(__dp__.dict((('a', 1),)), __dp__.dict(b)), __dp__.dict((('c', 2),)))
 
 $ expr 047
 a = ...
@@ -390,14 +390,14 @@ def _dp_gen_1(items):
             _dp_tmp_3 = __dp__.eq(__dp__.mod(a, 2), 0)
             if _dp_tmp_3:
                 yield __dp__.add(a, 1)
-r = list(_dp_gen_1(__dp__.iter(items)))
+r = __dp__.list(_dp_gen_1(__dp__.iter(items)))
 
 
 $ expr 052
 a = [1, 2, 3]
 =
 
-a = list((1, 2, 3))
+a = __dp__.list((1, 2, 3))
 
 
 $ expr 053
@@ -416,7 +416,7 @@ _dp_tmp_1
 $ expr 054
 a = [1, *b, 2]
 =
-a = list(__dp__.add(__dp__.add((1,), tuple(b)), (2,)))
+a = __dp__.list(__dp__.add(__dp__.add((1,), __dp__.tuple(b)), (2,)))
 
 $ expr 055
 a or b or c
@@ -460,7 +460,7 @@ def _dp_gen_1(items):
                     break
                 else:
                     yield __dp__.mul(a, b)
-r = list(_dp_gen_1(__dp__.iter(items)))
+r = __dp__.list(_dp_gen_1(__dp__.iter(items)))
 
 
 $ expr 058
@@ -487,7 +487,7 @@ def _dp_gen_1(items):
             break
         else:
             yield a
-r = set(_dp_gen_1(__dp__.iter(items)))
+r = __dp__.set(_dp_gen_1(__dp__.iter(items)))
 
 
 $ expr 061
@@ -506,7 +506,7 @@ $ expr 062
 a = {1, 2, 3}
 =
 
-a = set((1, 2, 3))
+a = __dp__.set((1, 2, 3))
 
 
 $ expr 063
@@ -534,7 +534,7 @@ __dp__.getitem(a, slice(None, 2, None))
 $ expr 067
 a = (1, *b, 2)
 =
-a = __dp__.add(__dp__.add((1,), tuple(b)), (2,))
+a = __dp__.add(__dp__.add((1,), __dp__.tuple(b)), (2,))
 
 $ expr 068
 -a

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -33,7 +33,7 @@ class Foo:
         return 1
 =
 def _dp_ns_Foo(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "Foo"

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -4,7 +4,7 @@ class C:
     x = 1
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -31,7 +31,7 @@ class C:
     x = x
 =
 def _dp_ns_C(_ns, x=x):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -59,7 +59,7 @@ class C:
     y = x
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -89,7 +89,7 @@ class C(B):
     pass
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -115,7 +115,7 @@ class C(B, metaclass=Meta, kw=1):
     x = 2
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -129,7 +129,7 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_ns, "x", x)
 def _dp_make_class_C():
     bases = __dp__.resolve_bases((B,))
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, dict((("metaclass", Meta), ("kw", 1))))
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, __dp__.dict((("metaclass", Meta), ("kw", 1))))
     meta = __dp__.getitem(_dp_tmp_3, 0)
     ns = __dp__.getitem(_dp_tmp_3, 1)
     kwds = __dp__.getitem(_dp_tmp_3, 2)
@@ -146,7 +146,7 @@ class C:
         return 1
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -181,7 +181,7 @@ class C:
         return super().m()
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -217,7 +217,7 @@ class C:
         return super().m()
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -257,7 +257,7 @@ class C:
         return self
 =
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -20,7 +20,7 @@ class C:
 def _dp_class_decorators_C(_dp_the_func):
     return dec(_dp_the_func)
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"
@@ -48,7 +48,7 @@ class C:
 def _dp_class_decorators_C(_dp_the_func):
     return dec2(5)(dec1(_dp_the_func))
 def _dp_ns_C(_ns):
-    _dp_temp_ns = dict(())
+    _dp_temp_ns = __dp__.dict(())
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_ns, "__module__", __name__)
     _dp_tmp_1 = "C"

--- a/src/transform/tests_rewrite_for_loop.txt
+++ b/src/transform/tests_rewrite_for_loop.txt
@@ -65,7 +65,7 @@ while True:
     try:
         _dp_tmp_2 = __dp__.next(_dp_iter_1)
         a = __dp__.getitem(_dp_tmp_2, 0)
-        b = tuple(__dp__.getitem(_dp_tmp_2, slice(1, None, None)))
+        b = __dp__.tuple(__dp__.getitem(_dp_tmp_2, slice(1, None, None)))
     except:
         __dp__.check_stopiteration()
         break

--- a/src/transform/tests_rewrite_import.txt
+++ b/src/transform/tests_rewrite_import.txt
@@ -8,13 +8,13 @@ $ rewrites from import
 
 from a.b import c
 =
-c = __dp__.import_("a.b", __spec__, list(("c",))).c
+c = __dp__.import_("a.b", __spec__, __dp__.list(("c",))).c
 
 $ rewrites relative import
 
 from ..a import b
 =
-b = __dp__.import_("a", __spec__, list(("b",)), 2).b
+b = __dp__.import_("a", __spec__, __dp__.list(("b",)), 2).b
 
 $ inserts after future and docstring
 
@@ -23,5 +23,5 @@ from __future__ import annotations
 x = 1
 =
 "doc"
-annotations = __dp__.import_("__future__", __spec__, list(("annotations",))).annotations
+annotations = __dp__.import_("__future__", __spec__, __dp__.list(("annotations",))).annotations
 x = 1

--- a/src/transform/tests_rewrite_match_case.txt
+++ b/src/transform/tests_rewrite_match_case.txt
@@ -171,7 +171,7 @@ if _dp_tmp_2:
     _dp_tmp_2 = _dp_tmp_3
 if _dp_tmp_2:
     first = __dp__.getitem(_dp_match_1, 0)
-    rest = list(__dp__.getitem(_dp_match_1, slice(1, __dp__.sub(len(_dp_match_1), 1), None)))
+    rest = __dp__.list(__dp__.getitem(_dp_match_1, slice(1, __dp__.sub(len(_dp_match_1), 1), None)))
     last = __dp__.getitem(_dp_match_1, __dp__.sub(len(_dp_match_1), 1))
     a()
 else:
@@ -200,7 +200,7 @@ if _dp_tmp_2:
     _dp_tmp_2 = _dp_tmp_5
 if _dp_tmp_2:
     a = __dp__.getitem(_dp_match_1, "a")
-    rest = dict(_dp_match_1)
+    rest = __dp__.dict(_dp_match_1)
     rest.pop("a", None)
     rest.pop("b", None)
     a()

--- a/src/transform/tests_rewrite_with.txt
+++ b/src/transform/tests_rewrite_with.txt
@@ -61,7 +61,7 @@ with a as (b, *c):
 _dp_tmp_2 = __dp__.with_enter(a)
 _dp_tmp_3 = __dp__.getitem(_dp_tmp_2, 0)
 b = __dp__.getitem(_dp_tmp_3, 0)
-c = tuple(__dp__.getitem(_dp_tmp_3, slice(1, None, None)))
+c = __dp__.tuple(__dp__.getitem(_dp_tmp_3, slice(1, None, None)))
 _dp_with_exit_1 = __dp__.getitem(_dp_tmp_2, 1)
 try:
     pass


### PR DESCRIPTION
## Summary
- expose tuple, list, dict, and set helpers from __dp__ so rewrites can avoid shadowed builtins
- update expression rewrites and related match/assignment lowering to invoke the new helpers
- refresh transform fixtures and the example desugared module to reflect the new output

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf1ff002e483248b45a10fd35e1c49