### PR TITLE
Remove DIET_PYTHON_TRANSFORMS from CPython test runner

### DIFF
--- a/scripts/run_cpython_tests.sh
+++ b/scripts/run_cpython_tests.sh
@@ -10,24 +10,6 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 export SOURCE_DATE_EPOCH="$(date +%s)"
 
-TRANSFORMS_SET=0
-TRANSFORMS=""
-ARGS=()
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    --transforms)
-      TRANSFORMS_SET=1
-      TRANSFORMS="$2"
-      shift 2
-      ;;
-    *)
-      ARGS+=("$1")
-      shift
-      ;;
-  esac
-done
-set -- "${ARGS[@]}"
-
 if ! command -v uv >/dev/null 2>&1; then
   echo "uv is required but not installed. Install it from https://astral.sh/uv." >&2
   exit 1
@@ -52,19 +34,10 @@ fi
 find "$CPYTHON_DIR" -name '*.pyc' -delete
 
 PYTHONPATH_PREFIX="$REPO_ROOT/$CPYTHON_DIR/Lib:$REPO_ROOT"
-if [ $TRANSFORMS_SET -eq 1 ]; then
-  (
-    cd "$CPYTHON_DIR" &&
-    PYTHONDONTWRITEBYTECODE=1 \
-    DIET_PYTHON_TRANSFORMS="$TRANSFORMS" \
-    PYTHONPATH="$PYTHONPATH_PREFIX${PYTHONPATH:+:$PYTHONPATH}" \
-    "../$VENV_DIR/bin/python" -m test -j0 "$@"
-  )
-else
-  (
-    cd "$CPYTHON_DIR" &&
-    PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONPATH="$PYTHONPATH_PREFIX${PYTHONPATH:+:$PYTHONPATH}" \
-    "../$VENV_DIR/bin/python" -m test -j0 "$@"
-  )
-fi
+
+(
+  cd "$CPYTHON_DIR" &&
+  PYTHONDONTWRITEBYTECODE=1 \
+  PYTHONPATH="$PYTHONPATH_PREFIX${PYTHONPATH:+:$PYTHONPATH}" \
+  "../$VENV_DIR/bin/python" -m test -j0 "$@"
+)


### PR DESCRIPTION
## Summary
- stop exporting the DIET_PYTHON_TRANSFORMS environment variable when running the CPython test suite
- drop support for the legacy --transforms option in the CPython test runner script

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf266d7998832493a75ef3318697a3