### PR TITLE
Ensure with helpers preserve context for exit handler

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -184,7 +184,7 @@ async def with_aenter(ctx):
     enter = type(ctx).__aenter__
     exit = type(ctx).__aexit__
     var = await enter(ctx)
-    return (var, exit)
+    return (var, (ctx, exit))
 
 
 async def with_aexit(state, exc_info: tuple | None):
@@ -200,7 +200,7 @@ def with_enter(ctx):
     enter = type(ctx).__enter__
     exit = type(ctx).__exit__
     var = enter(ctx)
-    return (var, exit)
+    return (var, (ctx, exit))
 
 
 def with_exit(state, exc_info: tuple | None):


### PR DESCRIPTION
## Summary
- update `__dp__.with_enter` and `__dp__.with_aenter` to return both the bound value and the `(ctx, exit)` state needed by their exit helpers

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf26014fb0832490d9d6713a507902