### PR TITLE
Reject elif chains in min_ast

### DIFF
--- a/src/min_ast.rs
+++ b/src/min_ast.rs
@@ -254,21 +254,16 @@ impl StmtNode {
                 ..
             }) => {
                 let mut orelse = Vec::new();
-                let mut elifs = Vec::new();
+                let mut seen_else = false;
                 for clause in elif_else_clauses {
-                    if let Some(test) = clause.test {
-                        elifs.push((test, clause.body));
-                    } else {
-                        orelse = StmtNode::from_stmts(clause.body, scope_vars);
+                    if clause.test.is_some() {
+                        panic!("elif clauses are not supported in min_ast");
                     }
-                }
-                for (test, body) in elifs.into_iter().rev() {
-                    orelse = vec![StmtNode::If {
-                        info: (),
-                        test: ExprNode::from(test),
-                        body: StmtNode::from_stmts(body, scope_vars),
-                        orelse,
-                    }];
+                    if seen_else {
+                        panic!("multiple else clauses not supported in min_ast");
+                    }
+                    seen_else = true;
+                    orelse = StmtNode::from_stmts(clause.body, scope_vars);
                 }
                 Some(StmtNode::If {
                     info: (),

--- a/src/transform/rewrite_match_case.rs
+++ b/src/transform/rewrite_match_case.rs
@@ -170,7 +170,8 @@ else:
                                 start = start_expr,
                                 end = end_expr
                             );
-                            let list_expr = py_expr!("__dp__.list({value:expr})", value = slice_expr);
+                            let list_expr =
+                                py_expr!("__dp__.list({value:expr})", value = slice_expr);
                             assigns.push(py_stmt!(
                                 "{name:id} = {value:expr}",
                                 name = name.as_str(),

--- a/src/transform/rewrite_truthy.rs
+++ b/src/transform/rewrite_truthy.rs
@@ -101,10 +101,11 @@ else:
         let expected = r#"
 if __dp__.truth(a):
     pass
-elif __dp__.truth(b):
-    pass
 else:
-    pass
+    if __dp__.truth(b):
+        pass
+    else:
+        pass
 "#;
         assert_transform_eq_truthy(input, expected);
     }

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -566,3 +566,21 @@ a[:]
 =
 __dp__.getitem(a, slice(None, None, None))
 
+$ expr 074
+def f():
+    if a:
+        return 1
+    elif b:
+        return 2
+    else:
+        return 3
+=
+def f():
+    if a:
+        return 1
+    else:
+        if b:
+            return 2
+        else:
+            return 3
+

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -17,10 +17,11 @@ else:
 =
 if True:
     x = 1
-elif False:
-    y = 2
 else:
-    z = 3
+    if False:
+        y = 2
+    else:
+        z = 3
 
 $ strips type alias from class body
 


### PR DESCRIPTION
## Summary
- reject `elif` clauses when lowering to `min_ast` and error on duplicate `else`

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf2924eb088324b436986ba3d8319c