### PR TITLE
Add integration test for preserving __orig_bases__

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -73,16 +73,24 @@ def _dp_ns_A(_ns):
     __dp__.setitem(_dp_temp_ns, "d", d)
     __dp__.setitem(_ns, "d", d)
 def _dp_make_class_A():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_5 = __dp__.prepare_class("A", bases, None)
     meta = __dp__.getitem(_dp_tmp_5, 0)
     ns = __dp__.getitem(_dp_tmp_5, 1)
     kwds = __dp__.getitem(_dp_tmp_5, 2)
     _dp_ns_A(ns)
+    _dp_tmp_7 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_6 = _dp_tmp_7
+    if _dp_tmp_6:
+        _dp_tmp_8 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_6 = _dp_tmp_8
+    if _dp_tmp_6:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("A", bases, ns, **kwds)
-_dp_tmp_6 = _dp_make_class_A()
-A = _dp_tmp_6
-_dp_class_A = _dp_tmp_6
+_dp_tmp_9 = _dp_make_class_A()
+A = _dp_tmp_9
+_dp_class_A = _dp_tmp_9
 def ff():
     a = A()
     __dp__.setattr(a, "b", 5)
@@ -92,42 +100,42 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
-def _dp_gen_7(_dp_iter_8):
-    _dp_iter_9 = __dp__.iter(_dp_iter_8)
+def _dp_gen_10(_dp_iter_11):
+    _dp_iter_12 = __dp__.iter(_dp_iter_11)
     while True:
         try:
-            i = __dp__.next(_dp_iter_9)
+            i = __dp__.next(_dp_iter_12)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_10 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_10:
+            _dp_tmp_13 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_13:
                 yield __dp__.add(i, 1)
-x = __dp__.list(_dp_gen_7(__dp__.iter(range(5))))
-def _dp_gen_11(_dp_iter_12):
-    _dp_iter_13 = __dp__.iter(_dp_iter_12)
+x = __dp__.list(_dp_gen_10(__dp__.iter(range(5))))
+def _dp_gen_14(_dp_iter_15):
+    _dp_iter_16 = __dp__.iter(_dp_iter_15)
     while True:
         try:
-            i = __dp__.next(_dp_iter_13)
+            i = __dp__.next(_dp_iter_16)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_14 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_14:
+            _dp_tmp_17 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_17:
                 yield __dp__.add(i, 1)
-y = __dp__.set(_dp_gen_11(__dp__.iter(range(5))))
-def _dp_gen_15(_dp_iter_16):
-    _dp_iter_17 = __dp__.iter(_dp_iter_16)
+y = __dp__.set(_dp_gen_14(__dp__.iter(range(5))))
+def _dp_gen_18(_dp_iter_19):
+    _dp_iter_20 = __dp__.iter(_dp_iter_19)
     while True:
         try:
-            i = __dp__.next(_dp_iter_17)
+            i = __dp__.next(_dp_iter_20)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_18 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_18:
+            _dp_tmp_21 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_21:
                 yield __dp__.add(i, 1)
-z = _dp_gen_15(__dp__.iter(range(5)))
+z = _dp_gen_18(__dp__.iter(range(5)))

--- a/src/transform/rewrite_class_def.rs
+++ b/src/transform/rewrite_class_def.rs
@@ -384,9 +384,12 @@ def _dp_ns_{class_name:id}(_ns):
     let make_fn = py_stmt!(
         r#"
 def _dp_make_class_{class_name:id}():
-    bases = __dp__.resolve_bases({bases:expr})
+    orig_bases = {bases:expr}
+    bases = __dp__.resolve_bases(orig_bases)
     meta, ns, kwds = __dp__.prepare_class({class_name:literal}, bases, {prepare_dict:expr})
     _dp_ns_{class_name:id}(ns)
+    if orig_bases is not bases and "__orig_bases__" not in ns:
+        ns["__orig_bases__"] = orig_bases
     return meta({class_name:literal}, bases, ns, **kwds)
 "#,
         bases = make_tuple(bases),

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -51,13 +51,21 @@ def _dp_ns_Foo(_ns):
     __dp__.setitem(_dp_temp_ns, "method", method)
     __dp__.setitem(_ns, "method", method)
 def _dp_make_class_Foo():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("Foo", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_Foo(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("Foo", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_Foo()
-Foo = _dp_tmp_3
-_dp_class_Foo = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_Foo()
+Foo = _dp_tmp_6
+_dp_class_Foo = _dp_tmp_6

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -14,16 +14,24 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_dp_temp_ns, "x", x)
     __dp__.setitem(_ns, "x", x)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6
 
 $ captures outer reference
 
@@ -41,16 +49,24 @@ def _dp_ns_C(_ns, x=x):
     __dp__.setitem(_dp_temp_ns, "x", x)
     __dp__.setitem(_ns, "x", x)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6
 
 $ preserves class locals for references
 
@@ -72,16 +88,24 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_dp_temp_ns, "y", y)
     __dp__.setitem(_ns, "y", y)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6
 
 $ lowers inherits
 
@@ -97,16 +121,24 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
     pass
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases((B,))
+    orig_bases = B,
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6
 
 $ lowers with docstring and keywords
 
@@ -128,16 +160,24 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_dp_temp_ns, "x", x)
     __dp__.setitem(_ns, "x", x)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases((B,))
+    orig_bases = B,
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_3 = __dp__.prepare_class("C", bases, __dp__.dict((("metaclass", Meta), ("kw", 1))))
     meta = __dp__.getitem(_dp_tmp_3, 0)
     ns = __dp__.getitem(_dp_tmp_3, 1)
     kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_4 = _dp_make_class_C()
-C = _dp_tmp_4
-_dp_class_C = _dp_tmp_4
+_dp_tmp_7 = _dp_make_class_C()
+C = _dp_tmp_7
+_dp_class_C = _dp_tmp_7
 
 $ lowers method
 
@@ -163,16 +203,24 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_ns, "m", m)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6
 
 $ rewrites super and class
 
@@ -199,16 +247,24 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_ns, "m", m)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6
 
 $ rewrites super uses first arg
 
@@ -235,16 +291,24 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_ns, "m", m)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6
 
 $ applies decorators in namespace
 
@@ -281,13 +345,21 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_ns, "m", m)
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
-_dp_tmp_3 = _dp_make_class_C()
-C = _dp_tmp_3
-_dp_class_C = _dp_tmp_3
+_dp_tmp_6 = _dp_make_class_C()
+C = _dp_tmp_6
+_dp_class_C = _dp_tmp_6

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -28,12 +28,20 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
     pass
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_decorators_C(_dp_class_C)
@@ -56,12 +64,20 @@ def _dp_ns_C(_ns):
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
     pass
 def _dp_make_class_C():
-    bases = __dp__.resolve_bases(())
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
     _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
     meta = __dp__.getitem(_dp_tmp_2, 0)
     ns = __dp__.getitem(_dp_tmp_2, 1)
     kwds = __dp__.getitem(_dp_tmp_2, 2)
     _dp_ns_C(ns)
+    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_3 = _dp_tmp_4
+    if _dp_tmp_3:
+        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_3 = _dp_tmp_5
+    if _dp_tmp_3:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_decorators_C(_dp_class_C)

--- a/tests/test_generic_orig_bases_integration.py
+++ b/tests/test_generic_orig_bases_integration.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+import diet_import_hook
+
+
+MODULE_SOURCE = """
+from typing import Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+class Box(Generic[T]):
+    pass
+
+
+def make_specialization():
+    class IntBox(Box[int]):
+        pass
+    return IntBox
+"""
+
+
+def _import_module(module_name: str, module_path: Path) -> ModuleType:
+    diet_import_hook.install()
+    module_dir = str(module_path.parent)
+    sys.path.insert(0, module_dir)
+    try:
+        return importlib.import_module(module_name)
+    finally:
+        if module_dir in sys.path:
+            sys.path.remove(module_dir)
+
+
+def test_generic_orig_bases_preserved(tmp_path):
+    module_name = "generic_module"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(MODULE_SOURCE, encoding="utf-8")
+
+    previous_typing = sys.modules.get("typing")
+    sys.modules.pop("typing", None)
+    sys.modules.pop(module_name, None)
+
+    module = _import_module(module_name, module_path)
+
+    try:
+        transformed_typing = sys.modules["typing"]
+        assert isinstance(
+            transformed_typing.__spec__.loader, diet_import_hook.DietPythonLoader
+        ), "typing should be transformed"
+
+        assert "__dp__" in module.__dict__, "module should be transformed"
+
+        assert module.Box.__orig_bases__ == (transformed_typing.Generic[module.T],)
+
+        specialized = module.make_specialization()
+        assert specialized.__orig_bases__[0].__args__ == (int,)
+        assert issubclass(specialized, module.Box)
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_typing is not None:
+            sys.modules["typing"] = previous_typing
+        else:
+            sys.modules.pop("typing", None)


### PR DESCRIPTION
## Summary
- add an integration test that imports a Generic subclass under the diet import hook
- verify both the stdlib typing module and the test module are transformed and preserve __orig_bases__ at runtime

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf3319f5388324b8582caff52c728b