### PR TITLE
Fix guard bindings in match rewrite

### DIFF
--- a/src/transform/tests_rewrite_match_case.txt
+++ b/src/transform/tests_rewrite_match_case.txt
@@ -28,12 +28,48 @@ match x:
         b()
 =
 _dp_match_1 = x
-_dp_tmp_3 = __dp__.eq(_dp_match_1, 1)
-_dp_tmp_2 = _dp_tmp_3
+_dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
 if _dp_tmp_2:
-    _dp_tmp_2 = cond
-if _dp_tmp_2:
+    if cond:
+        a()
+    else:
+        b()
+else:
+    b()
+
+$ rewrites guard with capture binding
+
+match x:
+    case iterable if not hasattr(iterable, "__next__"):
+        a()
+    case _:
+        b()
+=
+_dp_match_1 = x
+iterable = _dp_match_1
+if __dp__.not_(hasattr(iterable, "__next__")):
     a()
+else:
+    del iterable
+    b()
+
+$ rewrites guard with assignment and test
+
+match x:
+    case 1 as y if cond(y):
+        a()
+    case _:
+        b()
+=
+_dp_match_1 = x
+_dp_tmp_2 = __dp__.eq(_dp_match_1, 1)
+if _dp_tmp_2:
+    y = _dp_match_1
+    if cond(y):
+        a()
+    else:
+        del y
+        b()
 else:
     b()
 

--- a/tests/test_match_guard_bindings.py
+++ b/tests/test_match_guard_bindings.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+import diet_import_hook
+
+
+MODULE_SOURCE = """
+def probe(value):
+    match value:
+        case iterable if not hasattr(iterable, "__next__"):
+            return f"no next for {type(iterable).__name__}"
+        case _:
+            return "has next"
+"""
+
+
+def _import_module(module_name: str, module_path: Path) -> ModuleType:
+    diet_import_hook.install()
+    module_dir = str(module_path.parent)
+    sys.path.insert(0, module_dir)
+    try:
+        return importlib.import_module(module_name)
+    finally:
+        if module_dir in sys.path:
+            sys.path.remove(module_dir)
+
+
+def test_guard_bindings_are_available(tmp_path):
+    module_name = "match_guard"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(MODULE_SOURCE, encoding="utf-8")
+
+    sys.modules.pop(module_name, None)
+
+    module = _import_module(module_name, module_path)
+
+    try:
+        assert module.probe([1, 2, 3]) == "no next for list"
+        assert module.probe(iter([1, 2, 3])) == "has next"
+    finally:
+        sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Summary
- ensure match-case guards bind pattern variables before evaluating the guard and clean them up on failure
- add transform fixtures covering guarded capture patterns and assignments
- add an integration test that exercises guard bindings via the import hook

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf54abb85083249f339b1242fde616