### PR TITLE
Handle bare except without dummy exception access

### DIFF
--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -119,7 +119,6 @@ def _dp_ns_C(_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
-    pass
 def _dp_make_class_C():
     orig_bases = B,
     bases = __dp__.resolve_bases(orig_bases)

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -26,7 +26,6 @@ def _dp_ns_C(_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
-    pass
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
@@ -62,7 +61,6 @@ def _dp_ns_C(_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_ns, "__qualname__", _dp_tmp_1)
-    pass
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)

--- a/tests/test_try_except_integration.py
+++ b/tests/test_try_except_integration.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+import diet_import_hook
+
+
+MODULE_SOURCE = """
+_ = lambda text: f"translated:{text}"
+
+
+def translate_message():
+    _("before try")
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        return _("after except")
+
+
+def call_translate():
+    return translate_message()
+"""
+
+
+def test_bare_except_does_not_shadow_module_globals(tmp_path):
+    module_name = "translation_module"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(MODULE_SOURCE, encoding="utf-8")
+
+    module_dir = str(module_path.parent)
+    sys.path.insert(0, module_dir)
+    diet_import_hook.install()
+
+    try:
+        sys.modules.pop(module_name, None)
+        module = importlib.import_module(module_name)
+        assert module.call_translate() == "translated:after except"
+    finally:
+        sys.modules.pop(module_name, None)
+        if module_dir in sys.path:
+            sys.path.remove(module_dir)


### PR DESCRIPTION
## Summary
- restructure the try/except rewrite so bare handlers inline their body and typed handlers without aliases use a placeholder `pass`, plus add a regression test to lock in the new shape
- run a final transformer pass that strips placeholder `pass` statements from generated bodies and refresh the affected class decorator/class lowering fixtures

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf58177c188324b2f56395259a27e4