### PR TITLE
Refactor integration tests to use real modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import diet_import_hook
+import pytest
+
+_MODULES_DIR = Path(__file__).resolve().parent / "integration_modules"
+
+
+@contextmanager
+def _load_integration_module(module_name: str) -> Iterator[ModuleType]:
+    diet_import_hook.install()
+    module_dir = str(_MODULES_DIR)
+    module_path = _MODULES_DIR / f"{module_name}.py"
+    if not module_path.exists():
+        raise FileNotFoundError(
+            f"Integration module '{module_name}' not found at {module_path}"
+        )
+    sys.path.insert(0, module_dir)
+    try:
+        sys.modules.pop(module_name, None)
+        module = importlib.import_module(module_name)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        if module_dir in sys.path:
+            sys.path.remove(module_dir)
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "integration: mark a test as using integration modules")
+
+
+@pytest.fixture
+def run_integration_module():
+    return _load_integration_module

--- a/tests/integration_modules/generic_module.py
+++ b/tests/integration_modules/generic_module.py
@@ -1,0 +1,15 @@
+from typing import Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+class Box(Generic[T]):
+    pass
+
+
+def make_specialization():
+    class IntBox(Box[int]):
+        pass
+
+    return IntBox

--- a/tests/integration_modules/match_guard.py
+++ b/tests/integration_modules/match_guard.py
@@ -1,0 +1,6 @@
+def probe(value):
+    match value:
+        case iterable if not hasattr(iterable, "__next__"):
+            return f"no next for {type(iterable).__name__}"
+        case _:
+            return "has next"

--- a/tests/integration_modules/translation_module.py
+++ b/tests/integration_modules/translation_module.py
@@ -1,0 +1,13 @@
+_ = lambda text: f"translated:{text}"
+
+
+def translate_message():
+    _("before try")
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        return _("after except")
+
+
+def call_translate():
+    return translate_message()

--- a/tests/integration_modules/yield_from_module.py
+++ b/tests/integration_modules/yield_from_module.py
@@ -1,0 +1,22 @@
+def child():
+    events = []
+    try:
+        value = yield "start"
+        events.append(("send", value))
+        while True:
+            try:
+                value = yield value
+                events.append(("send", value))
+            except KeyError as exc:
+                events.append(("throw", str(exc)))
+                value = "handled"
+            if value == "stop":
+                break
+    finally:
+        events.append(("finally", None))
+    return events
+
+
+def delegator():
+    result = yield from child()
+    return ("done", result)

--- a/tests/test_generic_orig_bases_integration.py
+++ b/tests/test_generic_orig_bases_integration.py
@@ -1,72 +1,36 @@
 from __future__ import annotations
 
-import importlib
 import sys
-from pathlib import Path
 from types import ModuleType
-
-ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(ROOT))
 
 import diet_import_hook
 
 
-MODULE_SOURCE = """
-from typing import Generic, TypeVar
-
-
-T = TypeVar("T")
-
-
-class Box(Generic[T]):
-    pass
-
-
-def make_specialization():
-    class IntBox(Box[int]):
-        pass
-    return IntBox
-"""
-
-
-def _import_module(module_name: str, module_path: Path) -> ModuleType:
-    diet_import_hook.install()
-    module_dir = str(module_path.parent)
-    sys.path.insert(0, module_dir)
-    try:
-        return importlib.import_module(module_name)
-    finally:
-        if module_dir in sys.path:
-            sys.path.remove(module_dir)
-
-
-def test_generic_orig_bases_preserved(tmp_path):
+def test_generic_orig_bases_preserved(run_integration_module):
     module_name = "generic_module"
-    module_path = tmp_path / f"{module_name}.py"
-    module_path.write_text(MODULE_SOURCE, encoding="utf-8")
-
     previous_typing = sys.modules.get("typing")
     sys.modules.pop("typing", None)
-    sys.modules.pop(module_name, None)
-
-    module = _import_module(module_name, module_path)
 
     try:
-        transformed_typing = sys.modules["typing"]
-        assert isinstance(
-            transformed_typing.__spec__.loader, diet_import_hook.DietPythonLoader
-        ), "typing should be transformed"
-
-        assert "__dp__" in module.__dict__, "module should be transformed"
-
-        assert module.Box.__orig_bases__ == (transformed_typing.Generic[module.T],)
-
-        specialized = module.make_specialization()
-        assert specialized.__orig_bases__[0].__args__ == (int,)
-        assert issubclass(specialized, module.Box)
+        with run_integration_module(module_name) as module:
+            _assert_generic_module_invariants(module)
     finally:
-        sys.modules.pop(module_name, None)
         if previous_typing is not None:
             sys.modules["typing"] = previous_typing
         else:
             sys.modules.pop("typing", None)
+
+
+def _assert_generic_module_invariants(module: ModuleType) -> None:
+    transformed_typing = sys.modules["typing"]
+    assert isinstance(
+        transformed_typing.__spec__.loader, diet_import_hook.DietPythonLoader
+    ), "typing should be transformed"
+
+    assert "__dp__" in module.__dict__, "module should be transformed"
+
+    assert module.Box.__orig_bases__ == (transformed_typing.Generic[module.T],)
+
+    specialized = module.make_specialization()
+    assert specialized.__orig_bases__[0].__args__ == (int,)
+    assert issubclass(specialized, module.Box)

--- a/tests/test_match_guard_bindings.py
+++ b/tests/test_match_guard_bindings.py
@@ -1,48 +1,6 @@
 from __future__ import annotations
 
-import importlib
-import sys
-from pathlib import Path
-from types import ModuleType
-
-ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(ROOT))
-
-import diet_import_hook
-
-
-MODULE_SOURCE = """
-def probe(value):
-    match value:
-        case iterable if not hasattr(iterable, "__next__"):
-            return f"no next for {type(iterable).__name__}"
-        case _:
-            return "has next"
-"""
-
-
-def _import_module(module_name: str, module_path: Path) -> ModuleType:
-    diet_import_hook.install()
-    module_dir = str(module_path.parent)
-    sys.path.insert(0, module_dir)
-    try:
-        return importlib.import_module(module_name)
-    finally:
-        if module_dir in sys.path:
-            sys.path.remove(module_dir)
-
-
-def test_guard_bindings_are_available(tmp_path):
-    module_name = "match_guard"
-    module_path = tmp_path / f"{module_name}.py"
-    module_path.write_text(MODULE_SOURCE, encoding="utf-8")
-
-    sys.modules.pop(module_name, None)
-
-    module = _import_module(module_name, module_path)
-
-    try:
+def test_guard_bindings_are_available(run_integration_module):
+    with run_integration_module("match_guard") as module:
         assert module.probe([1, 2, 3]) == "no next for list"
         assert module.probe(iter([1, 2, 3])) == "has next"
-    finally:
-        sys.modules.pop(module_name, None)

--- a/tests/test_try_except_integration.py
+++ b/tests/test_try_except_integration.py
@@ -1,46 +1,5 @@
 from __future__ import annotations
 
-import importlib
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(ROOT))
-
-import diet_import_hook
-
-
-MODULE_SOURCE = """
-_ = lambda text: f"translated:{text}"
-
-
-def translate_message():
-    _("before try")
-    try:
-        raise RuntimeError("boom")
-    except RuntimeError:
-        return _("after except")
-
-
-def call_translate():
-    return translate_message()
-"""
-
-
-def test_bare_except_does_not_shadow_module_globals(tmp_path):
-    module_name = "translation_module"
-    module_path = tmp_path / f"{module_name}.py"
-    module_path.write_text(MODULE_SOURCE, encoding="utf-8")
-
-    module_dir = str(module_path.parent)
-    sys.path.insert(0, module_dir)
-    diet_import_hook.install()
-
-    try:
-        sys.modules.pop(module_name, None)
-        module = importlib.import_module(module_name)
+def test_bare_except_does_not_shadow_module_globals(run_integration_module):
+    with run_integration_module("translation_module") as module:
         assert module.call_translate() == "translated:after except"
-    finally:
-        sys.modules.pop(module_name, None)
-        if module_dir in sys.path:
-            sys.path.remove(module_dir)

--- a/tests/test_yield_from_integration.py
+++ b/tests/test_yield_from_integration.py
@@ -1,65 +1,10 @@
 from __future__ import annotations
 
-import importlib
-import sys
-from pathlib import Path
-from types import ModuleType
-
 import pytest
 
-ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(ROOT))
 
-import diet_import_hook
-
-
-def _import_module(module_name: str, module_path: Path) -> ModuleType:
-    diet_import_hook.install()
-    module_dir = str(module_path.parent)
-    sys.path.insert(0, module_dir)
-    try:
-        if module_name in sys.modules:
-            del sys.modules[module_name]
-        return importlib.import_module(module_name)
-    finally:
-        if module_dir in sys.path:
-            sys.path.remove(module_dir)
-
-
-def test_yield_from_delegation(tmp_path):
-    module_path = tmp_path / "yield_from_module.py"
-    module_path.write_text(
-        """
-
-def child():
-    events = []
-    try:
-        value = yield "start"
-        events.append(("send", value))
-        while True:
-            try:
-                value = yield value
-                events.append(("send", value))
-            except KeyError as exc:
-                events.append(("throw", str(exc)))
-                value = "handled"
-            if value == "stop":
-                break
-    finally:
-        events.append(("finally", None))
-    return events
-
-
-def delegator():
-    result = yield from child()
-    return ("done", result)
-""",
-        encoding="utf-8",
-    )
-
-    module = _import_module("yield_from_module", module_path)
-
-    try:
+def test_yield_from_delegation(run_integration_module):
+    with run_integration_module("yield_from_module") as module:
         assert "__dp__" in module.delegator.__code__.co_names
 
         gen = module.delegator()
@@ -79,6 +24,3 @@ def delegator():
             ("send", "stop"),
             ("finally", None),
         ]
-    finally:
-        if "yield_from_module" in sys.modules:
-            del sys.modules["yield_from_module"]


### PR DESCRIPTION
## Summary
- add a pytest fixture that installs the diet import hook and loads integration modules from disk
- convert integration test modules from inline strings to standalone Python files exercised via the new harness

## Testing
- pytest
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cfbe5bb6d08324bc38430cd52f8eb8