### PR TITLE
Fix decorator rewrite to preserve decorator evaluation order

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -1,11 +1,11 @@
 import __dp__
 sys = __dp__.import_("sys", __spec__)
 ei = __dp__.import_("sys", __spec__, __dp__.list(("exc_info",))).exc_info
-def _dp_decorator_add(_dp_the_func):
-    return foo(bar(1, 2)(_dp_the_func))
+_dp_decorator_add_0 = foo
+_dp_decorator_add_1 = bar(1, 2)
 def add(a, b):
     return __dp__.add(a, b)
-add = _dp_decorator_add(add)
+add = _dp_decorator_add_0(_dp_decorator_add_1(add))
 def _dp_ns_A(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -321,9 +321,8 @@ def _dp_ns_C(_dp_prepare_ns):
     y = deco
     __dp__.setitem(_dp_temp_ns, "y", y)
     __dp__.setitem(_dp_prepare_ns, "y", y)
-    def _dp_decorator_m(_dp_the_func):
-        return decorator(y)(other(_dp_the_func))
-
+    _dp_decorator_m_0 = decorator(y)
+    _dp_decorator_m_1 = other
     def _dp_mk_m():
 
         def m(self):
@@ -331,7 +330,7 @@ def _dp_ns_C(_dp_prepare_ns):
         __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
         return m
     m = _dp_mk_m()
-    m = _dp_decorator_m(m)
+    m = _dp_decorator_m_0(_dp_decorator_m_1(m))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
 def _dp_make_class_C():

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -5,11 +5,11 @@ $ rewrites function decorators
 def foo():
     pass
 =
-def _dp_decorator_foo(_dp_the_func):
-    return dec2(5)(dec1(_dp_the_func))
+_dp_decorator_foo_0 = dec2(5)
+_dp_decorator_foo_1 = dec1
 def foo():
     pass
-foo = _dp_decorator_foo(foo)
+foo = _dp_decorator_foo_0(_dp_decorator_foo_1(foo))
 
 $ rewrites class decorators
 
@@ -17,8 +17,7 @@ $ rewrites class decorators
 class C:
     pass
 =
-def _dp_decorator_C(_dp_the_func):
-    return dec(_dp_the_func)
+_dp_decorator_C_0 = dec
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
@@ -44,7 +43,7 @@ def _dp_make_class_C():
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_C
-C = _dp_decorator_C(C)
+C = _dp_decorator_C_0(C)
 
 $ rewrites multiple class decorators
 
@@ -53,8 +52,8 @@ $ rewrites multiple class decorators
 class C:
     pass
 =
-def _dp_decorator_C(_dp_the_func):
-    return dec2(5)(dec1(_dp_the_func))
+_dp_decorator_C_0 = dec2(5)
+_dp_decorator_C_1 = dec1
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
@@ -80,4 +79,20 @@ def _dp_make_class_C():
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_C
-C = _dp_decorator_C(C)
+C = _dp_decorator_C_0(_dp_decorator_C_1(C))
+
+$ preserves existing decorator targets
+
+atexit = property(lambda: None)
+
+@atexit.setter
+def atexit(value):
+    pass
+=
+def _dp_lambda_1():
+    return None
+atexit = property(_dp_lambda_1)
+_dp_decorator_atexit_0 = atexit.setter
+def atexit(value):
+    pass
+atexit = _dp_decorator_atexit_0(atexit)


### PR DESCRIPTION
## Summary
- evaluate decorator expressions before redefining the decorated symbol so property-based decorators retain access to the original binding
- update decorator/class transform fixtures and add a regression case covering property setter usage
- refresh example_desugar.py to match the new transform output

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06495182483248090a05f014013d3