### PR TITLE
Refactor statement rewrite guards into rewrite functions

### DIFF
--- a/src/transform/rewrite_assert.rs
+++ b/src/transform/rewrite_assert.rs
@@ -1,11 +1,12 @@
-use ruff_python_ast::{self as ast, Stmt};
+use super::expr::Rewrite;
+use ruff_python_ast::{self as ast};
 
 use crate::py_stmt;
 
-pub fn rewrite(ast::StmtAssert { test, msg, .. }: ast::StmtAssert) -> Vec<Stmt> {
+pub fn rewrite(ast::StmtAssert { test, msg, .. }: ast::StmtAssert) -> Rewrite {
     let test_expr = *test;
     if let Some(msg_expr) = msg {
-        py_stmt!(
+        Rewrite::Visit(py_stmt!(
             "
 if __debug__:
     if not {test:expr}:
@@ -13,16 +14,16 @@ if __debug__:
 ",
             test = test_expr,
             msg = *msg_expr
-        )
+        ))
     } else {
-        py_stmt!(
+        Rewrite::Visit(py_stmt!(
             "
 if __debug__:
     if not {test:expr}:
         raise AssertionError
 ",
             test = test_expr
-        )
+        ))
     }
 }
 

--- a/src/transform/rewrite_decorator.rs
+++ b/src/transform/rewrite_decorator.rs
@@ -1,4 +1,4 @@
-use super::context::Context;
+use super::{context::Context, expr::Rewrite};
 use ruff_python_ast::{self as ast, Stmt};
 
 use crate::{py_expr, py_stmt};
@@ -9,9 +9,9 @@ pub fn rewrite(
     name: &str,
     mut item: Vec<Stmt>,
     _ctx: &Context,
-) -> Vec<Stmt> {
+) -> Rewrite {
     if decorators.is_empty() {
-        return item;
+        return Rewrite::Walk(item);
     }
 
     let mut assignments: Vec<Stmt> = Vec::new();
@@ -44,7 +44,7 @@ pub fn rewrite(
         decorated = decorated
     ));
 
-    result
+    Rewrite::Visit(result)
 }
 
 #[cfg(test)]

--- a/src/transform/rewrite_for_loop.rs
+++ b/src/transform/rewrite_for_loop.rs
@@ -1,7 +1,7 @@
-use super::context::Context;
+use super::{context::Context, expr::Rewrite};
 use crate::body_transform::Transformer;
 use crate::py_stmt;
-use ruff_python_ast::{self as ast, Stmt};
+use ruff_python_ast::{self as ast};
 
 pub fn rewrite(
     ast::StmtFor {
@@ -14,7 +14,7 @@ pub fn rewrite(
     }: ast::StmtFor,
     ctx: &Context,
     transformer: &mut impl Transformer,
-) -> Vec<Stmt> {
+) -> Rewrite {
     let iter_name = ctx.fresh("iter");
 
     let mut rewritten = if is_async {
@@ -61,7 +61,7 @@ while True:
 
     transformer.visit_body(&mut rewritten);
 
-    rewritten
+    Rewrite::Visit(rewritten)
 }
 
 #[cfg(test)]

--- a/src/transform/rewrite_match_case.rs
+++ b/src/transform/rewrite_match_case.rs
@@ -1,4 +1,4 @@
-use super::context::Context;
+use super::{context::Context, expr::Rewrite};
 use ruff_python_ast::{self as ast, name::Name, Expr, Pattern, Stmt};
 use ruff_python_parser::parse_expression;
 use ruff_text_size::TextRange;
@@ -452,9 +452,9 @@ fn assigned_names(stmts: &[Stmt]) -> Vec<Name> {
     names
 }
 
-pub fn rewrite(ast::StmtMatch { subject, cases, .. }: ast::StmtMatch, ctx: &Context) -> Vec<Stmt> {
+pub fn rewrite(ast::StmtMatch { subject, cases, .. }: ast::StmtMatch, ctx: &Context) -> Rewrite {
     if cases.is_empty() {
-        return py_stmt!("pass");
+        return Rewrite::Visit(py_stmt!("pass"));
     }
 
     let subject_name = ctx.fresh("match");
@@ -558,13 +558,13 @@ else:
         }
     }
 
-    py_stmt!(
+    Rewrite::Visit(py_stmt!(
         "
 {assign:stmt}
 {chain:stmt}",
         assign = assign,
         chain = chain,
-    )
+    ))
 }
 
 #[cfg(test)]

--- a/src/transform/rewrite_with.rs
+++ b/src/transform/rewrite_with.rs
@@ -1,7 +1,7 @@
-use super::context::Context;
+use super::{context::Context, expr::Rewrite};
 use crate::body_transform::Transformer;
 use crate::{py_expr, py_stmt};
-use ruff_python_ast::{self as ast, Stmt};
+use ruff_python_ast::{self as ast};
 
 pub fn rewrite(
     ast::StmtWith {
@@ -12,9 +12,9 @@ pub fn rewrite(
     }: ast::StmtWith,
     ctx: &Context,
     transformer: &mut impl Transformer,
-) -> Vec<Stmt> {
+) -> Rewrite {
     if items.is_empty() {
-        return py_stmt!("pass");
+        return Rewrite::Visit(py_stmt!("pass"));
     }
 
     for ast::WithItem {
@@ -67,7 +67,7 @@ else:
     }
 
     transformer.visit_body(&mut body);
-    body
+    Rewrite::Visit(body)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- move statement rewrite guard checks into the helper modules and make them return `Rewrite`
- update the expression rewriter to rely on the new `Rewrite` interface, including a helper to extract statements
- adapt class, import, assignment, and other rewrite helpers to return `Rewrite` while preserving existing transformations

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06b74925c8324a66052ab16d32f96