### PR TITLE
Initialize class annotations once

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -13,6 +13,10 @@ def _dp_ns_A(_dp_prepare_ns):
     _dp_tmp_1 = "A"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
     b = 1
     __dp__.setitem(_dp_temp_ns, "b", b)
     __dp__.setitem(_dp_prepare_ns, "b", b)
@@ -40,10 +44,10 @@ def _dp_ns_A(_dp_prepare_ns):
     def _dp_mk_test_aiter():
 
         async def test_aiter(self):
-            _dp_iter_2 = __dp__.iter(range(10))
+            _dp_iter_3 = __dp__.iter(range(10))
             while True:
                 try:
-                    i = __dp__.next(_dp_iter_2)
+                    i = __dp__.next(_dp_iter_3)
                 except:
                     __dp__.check_stopiteration()
                     break
@@ -58,10 +62,10 @@ def _dp_ns_A(_dp_prepare_ns):
     def _dp_mk_d():
 
         async def d(self):
-            _dp_iter_3 = __dp__.aiter(self.test_aiter())
+            _dp_iter_4 = __dp__.aiter(self.test_aiter())
             while True:
                 try:
-                    i = await __dp__.anext(_dp_iter_3)
+                    i = await __dp__.anext(_dp_iter_4)
                 except:
                     __dp__.acheck_stopiteration()
                     break
@@ -75,17 +79,17 @@ def _dp_ns_A(_dp_prepare_ns):
 def _dp_make_class_A():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_4 = __dp__.prepare_class("A", bases, None)
-    meta = __dp__.getitem(_dp_tmp_4, 0)
-    ns = __dp__.getitem(_dp_tmp_4, 1)
-    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_tmp_5 = __dp__.prepare_class("A", bases, None)
+    meta = __dp__.getitem(_dp_tmp_5, 0)
+    ns = __dp__.getitem(_dp_tmp_5, 1)
+    kwds = __dp__.getitem(_dp_tmp_5, 2)
     _dp_ns_A(ns)
-    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_5 = _dp_tmp_6
-    if _dp_tmp_5:
-        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_5 = _dp_tmp_7
-    if _dp_tmp_5:
+    _dp_tmp_7 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_6 = _dp_tmp_7
+    if _dp_tmp_6:
+        _dp_tmp_8 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_6 = _dp_tmp_8
+    if _dp_tmp_6:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("A", bases, ns, **kwds)
 _dp_class_A = _dp_make_class_A()
@@ -99,42 +103,42 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
-def _dp_gen_8(_dp_iter_9):
-    _dp_iter_10 = __dp__.iter(_dp_iter_9)
+def _dp_gen_9(_dp_iter_10):
+    _dp_iter_11 = __dp__.iter(_dp_iter_10)
     while True:
         try:
-            i = __dp__.next(_dp_iter_10)
+            i = __dp__.next(_dp_iter_11)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_11 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_11:
+            _dp_tmp_12 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_12:
                 yield __dp__.add(i, 1)
-x = __dp__.list(_dp_gen_8(__dp__.iter(range(5))))
-def _dp_gen_12(_dp_iter_13):
-    _dp_iter_14 = __dp__.iter(_dp_iter_13)
+x = __dp__.list(_dp_gen_9(__dp__.iter(range(5))))
+def _dp_gen_13(_dp_iter_14):
+    _dp_iter_15 = __dp__.iter(_dp_iter_14)
     while True:
         try:
-            i = __dp__.next(_dp_iter_14)
+            i = __dp__.next(_dp_iter_15)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_15 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_15:
+            _dp_tmp_16 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_16:
                 yield __dp__.add(i, 1)
-y = __dp__.set(_dp_gen_12(__dp__.iter(range(5))))
-def _dp_gen_16(_dp_iter_17):
-    _dp_iter_18 = __dp__.iter(_dp_iter_17)
+y = __dp__.set(_dp_gen_13(__dp__.iter(range(5))))
+def _dp_gen_17(_dp_iter_18):
+    _dp_iter_19 = __dp__.iter(_dp_iter_18)
     while True:
         try:
-            i = __dp__.next(_dp_iter_18)
+            i = __dp__.next(_dp_iter_19)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_19 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_19:
+            _dp_tmp_20 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_20:
                 yield __dp__.add(i, 1)
-z = _dp_gen_16(__dp__.iter(range(5)))
+z = _dp_gen_17(__dp__.iter(range(5)))

--- a/py_stmt_match_macro/src/lib.rs
+++ b/py_stmt_match_macro/src/lib.rs
@@ -167,26 +167,57 @@ impl LiteralBuilder {
 
     fn parameter_to_rust_literal(&self, parameter: &Parameter) -> String {
         match parameter {
-            Parameter::Positional { name, default } => format!(
-                "Parameter::Positional {{ name: {name}, default: {default} }}",
+            Parameter::Positional {
+                name,
+                annotation,
+                default,
+            } => format!(
+                "Parameter::Positional {{ name: {name}, annotation: {annotation}, default: {default} }}",
                 name = self.string_literal(name),
+                annotation = self.option_literal(
+                    annotation
+                        .as_ref()
+                        .map(|expr| self.expr_to_rust_literal(expr))
+                ),
                 default = self
                     .option_literal(default.as_ref().map(|expr| self.expr_to_rust_literal(expr)))
             ),
-            Parameter::VarArg { name } => {
+            Parameter::VarArg { name, annotation } => {
                 format!(
-                    "Parameter::VarArg {{ name: {} }}",
-                    self.string_literal(name)
+                    "Parameter::VarArg {{ name: {}, annotation: {} }}",
+                    self.string_literal(name),
+                    self.option_literal(
+                        annotation
+                            .as_ref()
+                            .map(|expr| self.expr_to_rust_literal(expr))
+                    )
                 )
             }
-            Parameter::KwOnly { name, default } => format!(
-                "Parameter::KwOnly {{ name: {name}, default: {default} }}",
+            Parameter::KwOnly {
+                name,
+                annotation,
+                default,
+            } => format!(
+                "Parameter::KwOnly {{ name: {name}, annotation: {annotation}, default: {default} }}",
                 name = self.string_literal(name),
+                annotation = self.option_literal(
+                    annotation
+                        .as_ref()
+                        .map(|expr| self.expr_to_rust_literal(expr))
+                ),
                 default = self
                     .option_literal(default.as_ref().map(|expr| self.expr_to_rust_literal(expr)))
             ),
-            Parameter::KwArg { name } => {
-                format!("Parameter::KwArg {{ name: {} }}", self.string_literal(name))
+            Parameter::KwArg { name, annotation } => {
+                format!(
+                    "Parameter::KwArg {{ name: {}, annotation: {} }}",
+                    self.string_literal(name),
+                    self.option_literal(
+                        annotation
+                            .as_ref()
+                            .map(|expr| self.expr_to_rust_literal(expr))
+                    )
+                )
             }
         }
     }
@@ -310,10 +341,16 @@ impl LiteralBuilder {
 
     fn function_def_to_literal(&self, func: &FunctionDef) -> String {
         format!(
-            "FunctionDef {{ info: {info}, name: {name}, params: {params}, body: {body}, is_async: {is_async}, scope_vars: {scope} }}",
+            "FunctionDef {{ info: {info}, name: {name}, params: {params}, returns: {returns}, body: {body}, is_async: {is_async}, scope_vars: {scope} }}",
             info = self.info_to_literal(&func.info),
             name = self.string_literal(&func.name),
             params = self.parameters_to_literal(&func.params),
+            returns = self.option_literal(
+                func
+                    .returns
+                    .as_ref()
+                    .map(|expr| self.expr_to_rust_literal(expr))
+            ),
             body = self.stmt_vec_to_literal(&func.body),
             is_async = format!("{:?}", func.is_async),
             scope = self.outer_scope_vars_to_literal(&func.scope_vars)

--- a/src/template.rs
+++ b/src/template.rs
@@ -765,10 +765,7 @@ b = 2
 
     #[test]
     fn inserts_empty_stmt_from_iterator() {
-        let actual = py_stmt!(
-            "{body:stmt}",
-            body = Vec::<Stmt>::new().into_iter(),
-        );
+        let actual = py_stmt!("{body:stmt}", body = Vec::<Stmt>::new().into_iter(),);
         let expected: Vec<Stmt> = Vec::new();
         assert_ast_eq(actual, expected);
     }

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -40,6 +40,10 @@ def _dp_ns_Foo(_dp_prepare_ns):
     _dp_tmp_1 = "Foo"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
 
     def _dp_mk_method():
 
@@ -53,17 +57,17 @@ def _dp_ns_Foo(_dp_prepare_ns):
 def _dp_make_class_Foo():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("Foo", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("Foo", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_Foo(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("Foo", bases, ns, **kwds)
 _dp_class_Foo = _dp_make_class_Foo()

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -10,23 +10,72 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
     x = 1
     __dp__.setitem(_dp_temp_ns, "x", x)
     __dp__.setitem(_dp_prepare_ns, "x", x)
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
+    return meta("C", bases, ns, **kwds)
+_dp_class_C = _dp_make_class_C()
+C = _dp_class_C
+
+$ collects class annotations
+
+class C:
+    x: int
+    y: str = 1
+=
+def _dp_ns_C(_dp_prepare_ns):
+    _dp_temp_ns = __dp__.dict()
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
+    _dp_tmp_3 = __dp__.is_(_dp_temp_ns.get("__annotations__"), None)
     if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+        __dp__.setitem(_dp_temp_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setitem(_dp_prepare_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setitem(_dp_class_annotations, "x", int)
+    y = 1
+    __dp__.setitem(_dp_temp_ns, "y", y)
+    __dp__.setitem(_dp_prepare_ns, "y", y)
+    __dp__.setitem(_dp_class_annotations, "y", str)
+def _dp_make_class_C():
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_ns_C(ns)
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -44,23 +93,70 @@ def _dp_ns_C(_dp_prepare_ns, x=x):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
     x = x
     __dp__.setitem(_dp_temp_ns, "x", x)
     __dp__.setitem(_dp_prepare_ns, "x", x)
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
+        __dp__.setitem(ns, "__orig_bases__", orig_bases)
+    return meta("C", bases, ns, **kwds)
+_dp_class_C = _dp_make_class_C()
+C = _dp_class_C
+
+$ captures names used in annotations
+
+T = object()
+
+class C:
+    x: T
+=
+T = object()
+def _dp_ns_C(_dp_prepare_ns):
+    _dp_temp_ns = __dp__.dict()
+    __dp__.setitem(_dp_temp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
+    _dp_tmp_1 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
+    _dp_tmp_3 = __dp__.is_(_dp_temp_ns.get("__annotations__"), None)
     if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+        __dp__.setitem(_dp_temp_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setitem(_dp_prepare_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setitem(_dp_class_annotations, "x", T)
+def _dp_make_class_C():
+    orig_bases = ()
+    bases = __dp__.resolve_bases(orig_bases)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
+    _dp_ns_C(ns)
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -79,6 +175,10 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
     x = 1
     __dp__.setitem(_dp_temp_ns, "x", x)
     __dp__.setitem(_dp_prepare_ns, "x", x)
@@ -88,17 +188,17 @@ def _dp_ns_C(_dp_prepare_ns):
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -116,20 +216,24 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
 def _dp_make_class_C():
     orig_bases = B,
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -151,23 +255,27 @@ def _dp_ns_C(_dp_prepare_ns):
     __doc__ = 'doc'
     __dp__.setitem(_dp_temp_ns, "__doc__", __doc__)
     __dp__.setitem(_dp_prepare_ns, "__doc__", __doc__)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
     x = 2
     __dp__.setitem(_dp_temp_ns, "x", x)
     __dp__.setitem(_dp_prepare_ns, "x", x)
 def _dp_make_class_C():
     orig_bases = B,
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, __dp__.dict((("metaclass", Meta), ("kw", 1))))
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, __dp__.dict((("metaclass", Meta), ("kw", 1))))
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -186,6 +294,10 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
 
     def _dp_mk_m():
 
@@ -199,22 +311,21 @@ def _dp_ns_C(_dp_prepare_ns):
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_C
-
 $ rewrites super and class
 
 class C:
@@ -228,6 +339,10 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
 
     def _dp_mk_m():
 
@@ -242,22 +357,21 @@ def _dp_ns_C(_dp_prepare_ns):
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_C
-
 $ rewrites super uses first arg
 
 class C:
@@ -271,6 +385,10 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
 
     def _dp_mk_m():
 
@@ -285,22 +403,21 @@ def _dp_ns_C(_dp_prepare_ns):
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_C
-
 $ applies decorators in namespace
 
 class C:
@@ -318,11 +435,16 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
     y = deco
     __dp__.setitem(_dp_temp_ns, "y", y)
     __dp__.setitem(_dp_prepare_ns, "y", y)
     _dp_decorator_m_0 = decorator(y)
     _dp_decorator_m_1 = other
+
     def _dp_mk_m():
 
         def m(self):
@@ -336,17 +458,17 @@ def _dp_ns_C(_dp_prepare_ns):
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -11,6 +11,17 @@ def foo():
     pass
 foo = _dp_decorator_foo_0(_dp_decorator_foo_1(foo))
 
+$ preserves annotations on decorated functions
+
+@dec
+def foo(x: int) -> str:
+    pass
+=
+_dp_decorator_foo_0 = dec
+def foo(x: int) -> str:
+    pass
+foo = _dp_decorator_foo_0(foo)
+
 $ rewrites class decorators
 
 @dec
@@ -25,26 +36,29 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_C
 C = _dp_decorator_C_0(C)
-
 $ rewrites multiple class decorators
 
 @dec2(5)
@@ -61,26 +75,29 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_tmp_1 = "C"
     __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
     __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_class_annotations = _dp_temp_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_2 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_2, 0)
-    ns = __dp__.getitem(_dp_tmp_2, 1)
-    kwds = __dp__.getitem(_dp_tmp_2, 2)
+    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_3, 0)
+    ns = __dp__.getitem(_dp_tmp_3, 1)
+    kwds = __dp__.getitem(_dp_tmp_3, 2)
     _dp_ns_C(ns)
-    _dp_tmp_4 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_3 = _dp_tmp_4
-    if _dp_tmp_3:
-        _dp_tmp_5 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_3 = _dp_tmp_5
-    if _dp_tmp_3:
+    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_4 = _dp_tmp_5
+    if _dp_tmp_4:
+        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_4 = _dp_tmp_6
+    if _dp_tmp_4:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
 C = _dp_class_C
 C = _dp_decorator_C_0(_dp_decorator_C_1(C))
-
 $ preserves existing decorator targets
 
 atexit = property(lambda: None)

--- a/tests/test_cpython_transform_failures.py
+++ b/tests/test_cpython_transform_failures.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from tests._integration import transformed_module
 
 
@@ -19,7 +17,7 @@ class Example:
     assert Example.a is Example.b
 
 
-def test_dataclass_field_annotations_are_dropped(tmp_path: Path) -> None:
+def test_dataclass_field_annotations_are_retained(tmp_path: Path) -> None:
     source = """
 import dataclasses
 
@@ -31,5 +29,6 @@ class Example:
     with transformed_module(tmp_path, "dataclass_module", source) as module:
         Example = module.Example
 
-    with pytest.raises(TypeError, match="unexpected keyword argument 'value'"):
-        Example(value=1)
+    instance = Example(value=1)
+    assert instance.value == 1
+    assert Example.__annotations__["value"] is int


### PR DESCRIPTION
## Summary
- Initialize `_dp_class_annotations` at the start of every rewritten class and publish it to the namespace only when annotations are recorded.
- Refresh the class rewrite fixtures and integration outputs, including `example_desugar.py`, to reflect the eager annotations map initialization.

## Testing
- cargo test
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d08f1664a88324ad95fa7d35cda552