### PR TITLE
Fix nested class namespace handling

### DIFF
--- a/src/transform/rewrite_class_def.rs
+++ b/src/transform/rewrite_class_def.rs
@@ -355,6 +355,17 @@ _dp_temp_ns[{fn_name:literal}] = _dp_prepare_ns[{fn_name:literal}] = {fn_name:id
                     fn_name = fn_name.as_str(),
                 ));
             }
+            Stmt::ClassDef(mut class_def) => {
+                let nested_name = class_def.name.id.to_string();
+                let decorators = take(&mut class_def.decorator_list);
+
+                let nested_stmts = rewrite(class_def, decorators, rewriter).into_statements();
+                ns_body.extend(nested_stmts);
+                ns_body.extend(py_stmt!(
+                    "_dp_temp_ns[{name:literal}] = _dp_prepare_ns[{name:literal}] = {name:id}",
+                    name = nested_name.as_str(),
+                ));
+            }
             other => ns_body.push(other),
         }
     }

--- a/tests/test_cpython_transform_failures.py
+++ b/tests/test_cpython_transform_failures.py
@@ -32,3 +32,21 @@ class Example:
     instance = Example(value=1)
     assert instance.value == 1
     assert Example.__annotations__["value"] is int
+
+
+def test_nested_class_is_bound_to_enclosing_class(tmp_path: Path) -> None:
+    source = """
+class Container:
+    class Member:
+        pass
+
+
+def get_member() -> type | None:
+    return getattr(Container, "Member", None)
+"""
+
+    with transformed_module(tmp_path, "nested_class_binding", source) as module:
+        Container = module.Container
+        get_member = module.get_member
+
+    assert get_member() is Container.Member


### PR DESCRIPTION
## Summary
- replace the argparse-based regression with a self-contained nested-class fixture
- ensure nested class definitions in the class rewrite record their objects in the prepared namespace

## Testing
- cargo test
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0b3f7439c83248867e5dcd3b36c49