### PR TITLE
Ensure import_ raises ImportError for missing from-import names

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -117,7 +117,21 @@ def import_(name, spec, fromlist=None, level=0):
     if spec is not None:
         globals_dict["__package__"] = spec.parent
         globals_dict["__name__"] = spec.name
-    return builtins.__import__(name, globals_dict, {}, fromlist, level)
+    module = builtins.__import__(name, globals_dict, {}, fromlist, level)
+    if fromlist:
+        module_name = getattr(module, "__name__", name)
+        module_file = getattr(module, "__file__", None)
+        for attr in fromlist:
+            if attr == "*":
+                continue
+            try:
+                getattr(module, attr)
+            except AttributeError as exc:
+                message = f"cannot import name {attr!r} from {module_name!r}"
+                if module_file is not None:
+                    message = f"{message} ({module_file})"
+                raise ImportError(message, name=attr, path=module_file) from exc
+    return module
 
 
 # Tags as ints for yield from state machine

--- a/tests/integration_modules/missing_from_import.py
+++ b/tests/integration_modules/missing_from_import.py
@@ -1,0 +1,11 @@
+"""Exercise ``from module import name`` when ``name`` is absent."""
+
+from missing_from_import_target import VALUE
+
+
+try:
+    from missing_from_import_target import MISSING
+except ImportError:
+    RESULT = "fallback"
+else:
+    RESULT = MISSING

--- a/tests/integration_modules/missing_from_import_target.py
+++ b/tests/integration_modules/missing_from_import_target.py
@@ -1,0 +1,3 @@
+"""Helper module used to exercise ``from ... import`` behavior."""
+
+VALUE = "present"

--- a/tests/test_missing_from_import_integration.py
+++ b/tests/test_missing_from_import_integration.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_missing_from_import_raises_importerror(run_integration_module):
+    with run_integration_module("missing_from_import") as module:
+        assert module.RESULT == "fallback"


### PR DESCRIPTION
## Summary
- re-raise missing from-import attributes as ImportError so transformed modules match CPython semantics
- update the integration test to assert the fallback path without xfail

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0c253a180832485cf70069ec09870