### PR TITLE
Normalize ImportError metadata for missing from-import names

### DIFF
--- a/tests/integration_modules/missing_from_import.py
+++ b/tests/integration_modules/missing_from_import.py
@@ -1,0 +1,15 @@
+"""Exercise ``from module import name`` when ``name`` is absent."""
+
+from missing_from_import_target import VALUE
+
+
+try:
+    from missing_from_import_target import MISSING
+except ImportError as exc:
+    RESULT = "fallback"
+    ERROR_NAME = exc.name
+    ERROR_PATH = exc.path
+else:
+    RESULT = MISSING
+    ERROR_NAME = None
+    ERROR_PATH = None

--- a/tests/integration_modules/missing_from_import_target.py
+++ b/tests/integration_modules/missing_from_import_target.py
@@ -1,0 +1,3 @@
+"""Helper module used to exercise ``from ... import`` behavior."""
+
+VALUE = "present"

--- a/tests/test_missing_from_import_integration.py
+++ b/tests/test_missing_from_import_integration.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_missing_from_import_raises_importerror(run_integration_module):
+    with run_integration_module("missing_from_import") as module:
+        assert module.RESULT == "fallback"
+        assert module.ERROR_NAME == "missing_from_import_target"
+        assert module.ERROR_PATH is not None
+        assert module.ERROR_PATH.endswith("missing_from_import_target.py")


### PR DESCRIPTION
## Summary
- set ImportError.name to the originating module when re-raising missing from-import attributes
- capture ImportError metadata inside the missing-from-import integration module and assert it in the test

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0c253a180832485cf70069ec09870