### PR TITLE
Handle future annotations import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ fn should_skip(source: &str) -> bool {
 }
 
 fn apply_transforms(module: &mut ModModule, options: Options) {
+    transform::rewrite_future_annotations::rewrite(&mut module.body);
+
     // Lower `for` loops, expand generators and lambdas, and replace
     // `__dp__.<name>` calls with `getattr` in a single pass.
     let ctx = Context::new(options);

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod rewrite_decorator;
 pub(crate) mod rewrite_exception;
 pub(crate) mod rewrite_expr_to_stmt;
 pub(crate) mod rewrite_func_expr;
+pub(crate) mod rewrite_future_annotations;
 pub(crate) mod rewrite_import;
 pub(crate) mod rewrite_loop;
 pub(crate) mod rewrite_match_case;

--- a/src/transform/rewrite_future_annotations.rs
+++ b/src/transform/rewrite_future_annotations.rs
@@ -1,0 +1,100 @@
+use crate::body_transform::Transformer;
+use crate::py_expr;
+use ruff_python_ast::{self as ast, Expr, Stmt};
+use ruff_python_codegen::{Generator, Indentation};
+use ruff_source_file::LineEnding;
+
+pub fn rewrite(body: &mut Vec<Stmt>) {
+    let mut rewriter = FutureAnnotationsRewriter::new();
+    rewriter.strip_future_import(body);
+    if rewriter.enabled {
+        rewriter.visit_body(body);
+    }
+}
+
+struct FutureAnnotationsRewriter {
+    enabled: bool,
+    indent: Indentation,
+}
+
+impl FutureAnnotationsRewriter {
+    fn new() -> Self {
+        Self {
+            enabled: false,
+            indent: Indentation::new("    ".to_string()),
+        }
+    }
+
+    fn strip_future_import(&mut self, body: &mut Vec<Stmt>) {
+        let mut index = 0;
+        while index < body.len() {
+            let mut remove_stmt = false;
+            if let Stmt::ImportFrom(import_from) = &mut body[index] {
+                if is_future_annotations(import_from) {
+                    let before_len = import_from.names.len();
+                    import_from
+                        .names
+                        .retain(|alias| alias.name.id.as_str() != "annotations");
+                    if import_from.names.is_empty() {
+                        remove_stmt = true;
+                    }
+                    if import_from.names.len() != before_len {
+                        self.enabled = true;
+                    }
+                }
+            }
+
+            if remove_stmt {
+                body.remove(index);
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    fn annotation_string(&self, expr: &Expr) -> String {
+        Generator::new(&self.indent, LineEnding::default()).expr(expr)
+    }
+}
+
+impl Transformer for FutureAnnotationsRewriter {
+    fn visit_annotation(&mut self, expr: &mut Expr) {
+        let rendered = self.annotation_string(expr);
+        *expr = py_expr!("{literal:literal}", literal = rendered.as_str());
+    }
+}
+
+fn is_future_annotations(import_from: &ast::StmtImportFrom) -> bool {
+    import_from
+        .module
+        .as_ref()
+        .is_some_and(|module| module.id.as_str() == "__future__")
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast::Stmt;
+    use ruff_python_parser::parse_module;
+
+    use super::rewrite;
+
+    #[test]
+    fn preserves_other_future_imports() {
+        let mut module = parse_module(
+            "from __future__ import annotations, division\nfrom __future__ import generator_stop\n",
+        )
+        .unwrap()
+        .into_syntax();
+        rewrite(&mut module.body);
+        assert_eq!(module.body.len(), 2);
+        match &module.body[0] {
+            Stmt::ImportFrom(import_from) => {
+                assert_eq!(import_from.names.len(), 1);
+                assert_eq!(import_from.names[0].name.id.as_str(), "division");
+            }
+            other => panic!("expected future import, got {other:?}"),
+        }
+    }
+
+    crate::transform_fixture_test!("tests_rewrite_future_annotations.txt");
+}

--- a/src/transform/tests_rewrite_future_annotations.txt
+++ b/src/transform/tests_rewrite_future_annotations.txt
@@ -1,0 +1,28 @@
+$ rewrites function annotations
+
+from __future__ import annotations
+
+def f(x: list[int], y: dict[str, int]) -> tuple[str, ...]:
+    return x
+=
+def f(x: "list[int]", y: "dict[str, int]") -> "tuple[str, ...]":
+    return x
+
+$ preserves other future imports
+
+from __future__ import annotations, division
+
+def g(x: int | None):
+    pass
+=
+division = __dp__.import_("__future__", __spec__, __dp__.list(("division",))).division
+def g(x: "int | None"):
+    pass
+
+$ leaves annotations untouched without future import
+
+def h(x: list[int]):
+    return x
+=
+def h(x: __dp__.getitem(list, int)):
+    return x

--- a/src/transform/tests_rewrite_import.txt
+++ b/src/transform/tests_rewrite_import.txt
@@ -23,5 +23,4 @@ from __future__ import annotations
 x = 1
 =
 "doc"
-annotations = __dp__.import_("__future__", __spec__, __dp__.list(("annotations",))).annotations
 x = 1


### PR DESCRIPTION
## Summary
- add a transformer that strips `from __future__ import annotations` and stringifies annotations
- invoke the transformer in the main pipeline and update fixtures for the new behavior

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0d42d664083248b287c72e7713dc6