### PR TITLE
Fix generator helper parameter collisions

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -54,6 +54,7 @@ aiter = builtins.aiter
 anext = builtins.anext
 isinstance = builtins.isinstance
 setattr = builtins.setattr
+delattr = builtins.delattr
 tuple = builtins.tuple
 list = builtins.list
 dict = builtins.dict

--- a/src/transform/rewrite_assign_del.rs
+++ b/src/transform/rewrite_assign_del.rs
@@ -125,10 +125,13 @@ pub(crate) fn rewrite_ann_assign(
     rewriter: &mut ExprRewriter,
     ann_assign: ast::StmtAnnAssign,
 ) -> Rewrite {
-    let ast::StmtAnnAssign { target, value, .. } = ann_assign;
-    let value = match value {
-        Some(value) => value,
-        None => return Rewrite::Visit(vec![]),
+    let ast::StmtAnnAssign {
+        target,
+        value: Some(value),
+        ..
+    } = ann_assign
+    else {
+        return Rewrite::Walk(vec![Stmt::AnnAssign(ann_assign)]);
     };
 
     let mut stmts = Vec::new();

--- a/src/transform/rewrite_func_expr.rs
+++ b/src/transform/rewrite_func_expr.rs
@@ -60,12 +60,7 @@ pub(crate) fn rewrite_generator(
         .clone();
 
     let func_name = ctx.fresh("gen");
-
-    let param_name = if let Expr::Name(ast::ExprName { id, .. }) = &first_iter_expr {
-        id.clone()
-    } else {
-        Name::new(ctx.fresh("iter"))
-    };
+    let param_name = Name::new(ctx.fresh("iter"));
 
     let mut body = py_stmt!("yield {value:expr}", value = *elt);
 

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -72,7 +72,7 @@ raise ValueError
 $ expr 010
 x: int
 =
-
+x: int
 
 $ expr 011
 x: int = 1
@@ -299,19 +299,19 @@ $ expr 041
 r = {k: v + 1 for k, v in items if k % 2 == 0}
 =
 
-def _dp_gen_1(items):
-    _dp_iter_2 = __dp__.iter(items)
+def _dp_gen_1(_dp_iter_2):
+    _dp_iter_3 = __dp__.iter(_dp_iter_2)
     while True:
         try:
-            _dp_tmp_3 = __dp__.next(_dp_iter_2)
-            k = __dp__.getitem(_dp_tmp_3, 0)
-            v = __dp__.getitem(_dp_tmp_3, 1)
+            _dp_tmp_4 = __dp__.next(_dp_iter_3)
+            k = __dp__.getitem(_dp_tmp_4, 0)
+            v = __dp__.getitem(_dp_tmp_4, 1)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_4 = __dp__.eq(__dp__.mod(k, 2), 0)
-            if _dp_tmp_4:
+            _dp_tmp_5 = __dp__.eq(__dp__.mod(k, 2), 0)
+            if _dp_tmp_5:
                 yield k, __dp__.add(v, 1)
 r = __dp__.dict(_dp_gen_1(__dp__.iter(items)))
 
@@ -378,17 +378,17 @@ $ expr 051
 r = [a + 1 for a in items if a % 2 == 0]
 =
 
-def _dp_gen_1(items):
-    _dp_iter_2 = __dp__.iter(items)
+def _dp_gen_1(_dp_iter_2):
+    _dp_iter_3 = __dp__.iter(_dp_iter_2)
     while True:
         try:
-            a = __dp__.next(_dp_iter_2)
+            a = __dp__.next(_dp_iter_3)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_3 = __dp__.eq(__dp__.mod(a, 2), 0)
-            if _dp_tmp_3:
+            _dp_tmp_4 = __dp__.eq(__dp__.mod(a, 2), 0)
+            if _dp_tmp_4:
                 yield __dp__.add(a, 1)
 r = __dp__.list(_dp_gen_1(__dp__.iter(items)))
 
@@ -453,19 +453,19 @@ $ expr 057
 r = [a * b for a in items for b in items2]
 =
 
-def _dp_gen_1(items):
-    _dp_iter_2 = __dp__.iter(items)
+def _dp_gen_1(_dp_iter_2):
+    _dp_iter_3 = __dp__.iter(_dp_iter_2)
     while True:
         try:
-            a = __dp__.next(_dp_iter_2)
+            a = __dp__.next(_dp_iter_3)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_iter_3 = __dp__.iter(items2)
+            _dp_iter_4 = __dp__.iter(items2)
             while True:
                 try:
-                    b = __dp__.next(_dp_iter_3)
+                    b = __dp__.next(_dp_iter_4)
                 except:
                     __dp__.check_stopiteration()
                     break
@@ -488,11 +488,11 @@ $ expr 060
 r = {a for a in items}
 =
 
-def _dp_gen_1(items):
-    _dp_iter_2 = __dp__.iter(items)
+def _dp_gen_1(_dp_iter_2):
+    _dp_iter_3 = __dp__.iter(_dp_iter_2)
     while True:
         try:
-            a = __dp__.next(_dp_iter_2)
+            a = __dp__.next(_dp_iter_3)
         except:
             __dp__.check_stopiteration()
             break

--- a/src/transform/tests_rewrite_expr_to_stmt.txt
+++ b/src/transform/tests_rewrite_expr_to_stmt.txt
@@ -69,11 +69,11 @@ $ rewrites generator assignment
 
 x = (i for i in items)
 =
-def _dp_gen_1(items):
-    _dp_iter_2 = __dp__.iter(items)
+def _dp_gen_1(_dp_iter_2):
+    _dp_iter_3 = __dp__.iter(_dp_iter_2)
     while True:
         try:
-            i = __dp__.next(_dp_iter_2)
+            i = __dp__.next(_dp_iter_3)
         except:
             __dp__.check_stopiteration()
             break

--- a/tests/integration_modules/comprehension_scope_shadowing.py
+++ b/tests/integration_modules/comprehension_scope_shadowing.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class Scope(Enum):
+    Function = "function"
+    Module = "module"
+
+
+HIGH_SCOPES = [scope for scope in Scope if scope is Scope.Function]
+FUNCTION_MEMBERS = [Scope.Function for scope in Scope if scope is Scope.Function]

--- a/tests/integration_modules/delattr_missing.py
+++ b/tests/integration_modules/delattr_missing.py
@@ -1,0 +1,11 @@
+"""Ensure the transform rewrites `del` to `__dp__.delattr` correctly."""
+
+
+class Example:
+    pass
+
+
+INSTANCE = Example()
+INSTANCE.value = 1
+del INSTANCE.value
+ATTRIBUTE_DELETED = not hasattr(INSTANCE, "value")

--- a/tests/integration_modules/dotted_import_alias.py
+++ b/tests/integration_modules/dotted_import_alias.py
@@ -1,0 +1,4 @@
+import dotted_import_alias_pkg.submodule as submodule
+
+VALUE = submodule.SENTINEL
+MODULE_NAME = submodule.__name__

--- a/tests/integration_modules/dotted_import_alias_pkg/__init__.py
+++ b/tests/integration_modules/dotted_import_alias_pkg/__init__.py
@@ -1,0 +1,1 @@
+SENTINEL = "package"

--- a/tests/integration_modules/dotted_import_alias_pkg/submodule.py
+++ b/tests/integration_modules/dotted_import_alias_pkg/submodule.py
@@ -1,0 +1,1 @@
+SENTINEL = "submodule"

--- a/tests/integration_modules/type_checking_annotations.py
+++ b/tests/integration_modules/type_checking_annotations.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+SENTINEL = object()
+
+
+class Marker:
+    if TYPE_CHECKING:
+        typed_attr: int
+        other_attr: str
+
+    value = SENTINEL

--- a/tests/test_comprehension_scope_shadowing_integration.py
+++ b/tests/test_comprehension_scope_shadowing_integration.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def test_comprehension_scope_shadowing(run_integration_module):
+    with run_integration_module("comprehension_scope_shadowing") as module:
+        assert module.HIGH_SCOPES == [module.Scope.Function]
+        assert module.FUNCTION_MEMBERS == [module.Scope.Function]

--- a/tests/test_delattr_helper_integration.py
+++ b/tests/test_delattr_helper_integration.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_delattr_helper_supported(run_integration_module) -> None:
+    with run_integration_module("delattr_missing") as module:
+        assert module.ATTRIBUTE_DELETED is True

--- a/tests/test_dotted_import_alias_integration.py
+++ b/tests/test_dotted_import_alias_integration.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def test_import_dotted_module_alias(run_integration_module):
+    with run_integration_module("dotted_import_alias") as module:
+        assert module.VALUE == "submodule"
+        assert module.MODULE_NAME == "dotted_import_alias_pkg.submodule"

--- a/tests/test_type_checking_annotations_integration.py
+++ b/tests/test_type_checking_annotations_integration.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def test_type_checking_annotations_preserve_class_body(run_integration_module):
+    with run_integration_module("type_checking_annotations") as module:
+        assert module.Marker.value is module.SENTINEL
+        assert not hasattr(module.Marker, "typed_attr")


### PR DESCRIPTION
## Summary
- allocate a fresh iterator parameter name for rewritten generator helpers so comprehensions no longer shadow globals like `Scope`
- update the comprehension rewrite fixtures to reflect the new helper parameter naming
- add integration coverage for enum comprehensions that reference the enum class during iteration

## Testing
- `cargo test`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD python -m pytest -q` *(fails: AttributeError: module `_pytest` has no attribute `local`)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d63df3e48324989355a75e9ec86e