### PR TITLE
Fix stdlib import alias transform

### DIFF
--- a/src/transform/rewrite_import.rs
+++ b/src/transform/rewrite_import.rs
@@ -26,7 +26,8 @@ pub fn rewrite(ast::StmtImport { names, .. }: ast::StmtImport) -> Rewrite {
                     .as_ref()
                     .map(|n| n.id.as_str())
                     .unwrap_or_else(|| module_name.split('.').next().unwrap());
-                if alias.asname.is_some() {
+                let needs_fromlist = alias.asname.is_some() && module_name.contains('.');
+                if needs_fromlist {
                     let attr = module_name
                         .rsplit_once('.')
                         .map(|(_, last)| last)

--- a/src/transform/tests_rewrite_import.txt
+++ b/src/transform/tests_rewrite_import.txt
@@ -14,7 +14,7 @@ $ rewrites aliased import
 
 import a as b
 =
-b = __dp__.import_("a", __spec__, __dp__.list(("a",)))
+b = __dp__.import_("a", __spec__)
 
 $ rewrites dotted aliased import
 

--- a/tests/integration_modules/stdlib_import_alias.py
+++ b/tests/integration_modules/stdlib_import_alias.py
@@ -1,0 +1,5 @@
+"""Reproduces the failure when importing a stdlib module with an alias."""
+
+import sys as sys_alias
+
+VALUE = sys_alias.version

--- a/tests/test_dotted_import_alias_integration.py
+++ b/tests/test_dotted_import_alias_integration.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 
 def test_import_dotted_module_alias(run_integration_module):
     with run_integration_module("dotted_import_alias") as module:
         assert module.VALUE == "submodule"
         assert module.MODULE_NAME == "dotted_import_alias_pkg.submodule"
+
+
+def test_import_stdlib_module_alias(run_integration_module):
+    with run_integration_module("stdlib_import_alias") as module:
+        assert module.VALUE == __import__("sys").version


### PR DESCRIPTION
## Summary
- avoid adding a fromlist when rewriting aliased imports of top-level modules
- update the import transform fixture to reflect the new alias behavior
- enable the stdlib alias integration test now that the transform handles it

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16993fe6c832490d27d6da50c0513