### PR TITLE
Handle circular imports in import helper

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -134,6 +134,11 @@ def import_(name, spec, fromlist=None, level=0):
             try:
                 getattr(module, attr)
             except AttributeError as exc:
+                if module_name:
+                    submodule = sys.modules.get(f"{module_name}.{attr}")
+                    if submodule is not None:
+                        setattr(module, attr, submodule)
+                        continue
                 message = f"cannot import name {attr!r} from {module_name!r}"
                 if module_file is not None:
                     message = f"{message} ({module_file})"

--- a/tests/test_circular_import_integration.py
+++ b/tests/test_circular_import_integration.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+import diet_import_hook
+
+
+def _write(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+
+
+def test_circular_relative_import(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+
+    _write(pkg / "__init__.py", "from . import a\n")
+    _write(pkg / "a.py", "from . import b\n")
+    _write(pkg / "b.py", "from . import a\n")
+
+    sys.path.insert(0, str(tmp_path))
+    diet_import_hook.install()
+
+    try:
+        module = importlib.import_module("pkg.a")
+        assert hasattr(module, "b")
+    finally:
+        for name in ["pkg", "pkg.a", "pkg.b"]:
+            sys.modules.pop(name, None)
+        sys.path.remove(str(tmp_path))


### PR DESCRIPTION
## Summary
- allow `__dp__.import_` to attach partially initialized submodules discovered in `sys.modules`
- enable the circular relative import integration test to verify the fix

## Testing
- cargo test
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68d16e04e7308324955ea75f8e741180