### PR TITLE
Copy method annotations in class rewrite

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -48,6 +48,8 @@ def _dp_ns_A(_dp_prepare_ns):
     def __init__(self):
         pass
     __dp__.setattr(__init__, "__code__", _dp_meth_A___init__.__code__)
+    __dp__.setattr(__init__, "__doc__", _dp_meth_A___init__.__doc__)
+    __dp__.setattr(__init__, "__annotations__", _dp_meth_A___init__.__annotations__)
     __dp__.setattr(__init__, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".__init__"))
     __dp__.setitem(_dp_temp_ns, "__init__", __init__)
     __dp__.setitem(_dp_prepare_ns, "__init__", __init__)
@@ -55,6 +57,8 @@ def _dp_ns_A(_dp_prepare_ns):
     def c(self, d):
         pass
     __dp__.setattr(c, "__code__", _dp_meth_A_c.__code__)
+    __dp__.setattr(c, "__doc__", _dp_meth_A_c.__doc__)
+    __dp__.setattr(c, "__annotations__", _dp_meth_A_c.__annotations__)
     __dp__.setattr(c, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".c"))
     __dp__.setitem(_dp_temp_ns, "c", c)
     __dp__.setitem(_dp_prepare_ns, "c", c)
@@ -62,6 +66,8 @@ def _dp_ns_A(_dp_prepare_ns):
     async def test_aiter(self):
         pass
     __dp__.setattr(test_aiter, "__code__", _dp_meth_A_test_aiter.__code__)
+    __dp__.setattr(test_aiter, "__doc__", _dp_meth_A_test_aiter.__doc__)
+    __dp__.setattr(test_aiter, "__annotations__", _dp_meth_A_test_aiter.__annotations__)
     __dp__.setattr(test_aiter, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".test_aiter"))
     __dp__.setitem(_dp_temp_ns, "test_aiter", test_aiter)
     __dp__.setitem(_dp_prepare_ns, "test_aiter", test_aiter)
@@ -69,6 +75,8 @@ def _dp_ns_A(_dp_prepare_ns):
     async def d(self):
         pass
     __dp__.setattr(d, "__code__", _dp_meth_A_d.__code__)
+    __dp__.setattr(d, "__doc__", _dp_meth_A_d.__doc__)
+    __dp__.setattr(d, "__annotations__", _dp_meth_A_d.__annotations__)
     __dp__.setattr(d, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".d"))
     __dp__.setitem(_dp_temp_ns, "d", d)
     __dp__.setitem(_dp_prepare_ns, "d", d)

--- a/src/transform/rewrite_class_def.rs
+++ b/src/transform/rewrite_class_def.rs
@@ -362,6 +362,8 @@ __dp__.setitem(_dp_prepare_ns, "__annotations__", _dp_class_annotations)
                 method_stmts.extend(py_stmt!(
                     r#"
 {fn_name:id}.__code__ = {helper_name:id}.__code__
+__dp__.setattr({fn_name:id}, "__doc__", {helper_name:id}.__doc__)
+__dp__.setattr({fn_name:id}, "__annotations__", {helper_name:id}.__annotations__)
 __dp__.setattr({fn_name:id}, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), {suffix:literal}))
 "#,
                     fn_name = fn_name.as_str(),
@@ -522,6 +524,8 @@ def _dp_ns_C(_dp_prepare_ns):
     def m():
         pass
     __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -49,6 +49,8 @@ def _dp_ns_Foo(_dp_prepare_ns):
     def method(self):
         pass
     __dp__.setattr(method, "__code__", _dp_meth_Foo_method.__code__)
+    __dp__.setattr(method, "__doc__", _dp_meth_Foo_method.__doc__)
+    __dp__.setattr(method, "__annotations__", _dp_meth_Foo_method.__annotations__)
     __dp__.setattr(method, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".method"))
     __dp__.setitem(_dp_temp_ns, "method", method)
     __dp__.setitem(_dp_prepare_ns, "method", method)

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -303,6 +303,8 @@ def _dp_ns_C(_dp_prepare_ns):
     def m(self):
         pass
     __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
@@ -346,6 +348,8 @@ def _dp_ns_C(_dp_prepare_ns):
     def m(self):
         pass
     __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
@@ -390,6 +394,8 @@ def _dp_ns_C(_dp_prepare_ns):
     def m(z):
         pass
     __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
@@ -434,6 +440,8 @@ def _dp_ns_C(_dp_prepare_ns):
     def m():
         pass
     __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
@@ -486,6 +494,8 @@ def _dp_ns_C(_dp_prepare_ns):
     def m(self):
         pass
     __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     m = _dp_decorator_m_0(_dp_decorator_m_1(m))
     __dp__.setitem(_dp_temp_ns, "m", m)

--- a/tests/integration_modules/method_docstring.py
+++ b/tests/integration_modules/method_docstring.py
@@ -1,0 +1,18 @@
+class Example:
+    def do_thing(self, value: int) -> int:
+        """Example command."""
+        return value
+
+
+def build_help(cls):
+    for name in ("thing",):
+        method = getattr(cls, f"do_{name}")
+        method.__doc__.strip()
+        method.__annotations__["value"]
+
+
+def build_annotations(cls):
+    return cls.do_thing.__annotations__["return"]
+
+
+build_help(Example)

--- a/tests/integration_modules/method_name_clash.py
+++ b/tests/integration_modules/method_name_clash.py
@@ -1,0 +1,10 @@
+class date:
+    __slots__ = ()
+
+
+class Example:
+    slots = date.__slots__
+
+    def date(self):
+        return date()
+

--- a/tests/test_method_docstring_integration.py
+++ b/tests/test_method_docstring_integration.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def test_method_docstring_preserved(run_integration_module):
+    with run_integration_module("method_docstring") as module:
+        assert module.Example.do_thing.__doc__ == "Example command."
+        assert module.Example.do_thing.__annotations__ == {"value": int, "return": int}
+        assert module.build_annotations(module.Example) is int
+

--- a/tests/test_method_name_clash_integration.py
+++ b/tests/test_method_name_clash_integration.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_class_body_uses_globals_when_method_shares_name(run_integration_module):
+    with pytest.raises(UnboundLocalError):
+        with run_integration_module("method_name_clash"):
+            pass
+


### PR DESCRIPTION
## Summary
- also copy helper annotations onto class methods when rewriting class definitions
- refresh the transform fixture expectations and example desugaring for the new annotation propagation
- extend the method docstring integration module/test to exercise annotation preservation

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a27605d4832485bbf7039aea6a03