### PR TITLE
Use fresh helper names for rewritten methods

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -6,25 +6,25 @@ _dp_decorator_add_1 = bar(1, 2)
 def add(a, b):
     return __dp__.add(a, b)
 add = _dp_decorator_add_0(_dp_decorator_add_1(add))
-def _dp_meth_A___init__(self):
+def _dp_meth_A___init___1(self):
     __dp__.setattr(self, "arr", __dp__.list((1, 2, 3)))
-def _dp_meth_A_c(self, d):
+def _dp_meth_A_c_2(self, d):
     return add(d, 2)
-async def _dp_meth_A_test_aiter(self):
-    _dp_iter_1 = __dp__.iter(range(10))
+async def _dp_meth_A_test_aiter_3(self):
+    _dp_iter_5 = __dp__.iter(range(10))
     while True:
         try:
-            i = __dp__.next(_dp_iter_1)
+            i = __dp__.next(_dp_iter_5)
         except:
             __dp__.check_stopiteration()
             break
         else:
             yield i
-async def _dp_meth_A_d(self):
-    _dp_iter_2 = __dp__.aiter(self.test_aiter())
+async def _dp_meth_A_d_4(self):
+    _dp_iter_6 = __dp__.aiter(self.test_aiter())
     while True:
         try:
-            i = await __dp__.anext(_dp_iter_2)
+            i = await __dp__.anext(_dp_iter_6)
         except:
             __dp__.acheck_stopiteration()
             break
@@ -34,12 +34,12 @@ def _dp_ns_A(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_3 = "A"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_3)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_3)
+    _dp_tmp_7 = "A"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_7)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_7)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_4 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_4:
+    _dp_tmp_8 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_8:
         _dp_class_annotations = __dp__.dict()
     b = 1
     __dp__.setitem(_dp_temp_ns, "b", b)
@@ -47,53 +47,53 @@ def _dp_ns_A(_dp_prepare_ns):
 
     def __init__(self):
         pass
-    __dp__.setattr(__init__, "__code__", _dp_meth_A___init__.__code__)
-    __dp__.setattr(__init__, "__doc__", _dp_meth_A___init__.__doc__)
-    __dp__.setattr(__init__, "__annotations__", _dp_meth_A___init__.__annotations__)
+    __dp__.setattr(__init__, "__code__", _dp_meth_A___init___1.__code__)
+    __dp__.setattr(__init__, "__doc__", _dp_meth_A___init___1.__doc__)
+    __dp__.setattr(__init__, "__annotations__", _dp_meth_A___init___1.__annotations__)
     __dp__.setattr(__init__, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".__init__"))
     __dp__.setitem(_dp_temp_ns, "__init__", __init__)
     __dp__.setitem(_dp_prepare_ns, "__init__", __init__)
 
     def c(self, d):
         pass
-    __dp__.setattr(c, "__code__", _dp_meth_A_c.__code__)
-    __dp__.setattr(c, "__doc__", _dp_meth_A_c.__doc__)
-    __dp__.setattr(c, "__annotations__", _dp_meth_A_c.__annotations__)
+    __dp__.setattr(c, "__code__", _dp_meth_A_c_2.__code__)
+    __dp__.setattr(c, "__doc__", _dp_meth_A_c_2.__doc__)
+    __dp__.setattr(c, "__annotations__", _dp_meth_A_c_2.__annotations__)
     __dp__.setattr(c, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".c"))
     __dp__.setitem(_dp_temp_ns, "c", c)
     __dp__.setitem(_dp_prepare_ns, "c", c)
 
     async def test_aiter(self):
         pass
-    __dp__.setattr(test_aiter, "__code__", _dp_meth_A_test_aiter.__code__)
-    __dp__.setattr(test_aiter, "__doc__", _dp_meth_A_test_aiter.__doc__)
-    __dp__.setattr(test_aiter, "__annotations__", _dp_meth_A_test_aiter.__annotations__)
+    __dp__.setattr(test_aiter, "__code__", _dp_meth_A_test_aiter_3.__code__)
+    __dp__.setattr(test_aiter, "__doc__", _dp_meth_A_test_aiter_3.__doc__)
+    __dp__.setattr(test_aiter, "__annotations__", _dp_meth_A_test_aiter_3.__annotations__)
     __dp__.setattr(test_aiter, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".test_aiter"))
     __dp__.setitem(_dp_temp_ns, "test_aiter", test_aiter)
     __dp__.setitem(_dp_prepare_ns, "test_aiter", test_aiter)
 
     async def d(self):
         pass
-    __dp__.setattr(d, "__code__", _dp_meth_A_d.__code__)
-    __dp__.setattr(d, "__doc__", _dp_meth_A_d.__doc__)
-    __dp__.setattr(d, "__annotations__", _dp_meth_A_d.__annotations__)
+    __dp__.setattr(d, "__code__", _dp_meth_A_d_4.__code__)
+    __dp__.setattr(d, "__doc__", _dp_meth_A_d_4.__doc__)
+    __dp__.setattr(d, "__annotations__", _dp_meth_A_d_4.__annotations__)
     __dp__.setattr(d, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".d"))
     __dp__.setitem(_dp_temp_ns, "d", d)
     __dp__.setitem(_dp_prepare_ns, "d", d)
 def _dp_make_class_A():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_5 = __dp__.prepare_class("A", bases, None)
-    meta = __dp__.getitem(_dp_tmp_5, 0)
-    ns = __dp__.getitem(_dp_tmp_5, 1)
-    kwds = __dp__.getitem(_dp_tmp_5, 2)
+    _dp_tmp_9 = __dp__.prepare_class("A", bases, None)
+    meta = __dp__.getitem(_dp_tmp_9, 0)
+    ns = __dp__.getitem(_dp_tmp_9, 1)
+    kwds = __dp__.getitem(_dp_tmp_9, 2)
     _dp_ns_A(ns)
-    _dp_tmp_7 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_6 = _dp_tmp_7
-    if _dp_tmp_6:
-        _dp_tmp_8 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_6 = _dp_tmp_8
-    if _dp_tmp_6:
+    _dp_tmp_11 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_10 = _dp_tmp_11
+    if _dp_tmp_10:
+        _dp_tmp_12 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_10 = _dp_tmp_12
+    if _dp_tmp_10:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("A", bases, ns, **kwds)
 _dp_class_A = _dp_make_class_A()
@@ -107,19 +107,6 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
-def _dp_gen_9(_dp_iter_10):
-    _dp_iter_11 = __dp__.iter(_dp_iter_10)
-    while True:
-        try:
-            i = __dp__.next(_dp_iter_11)
-        except:
-            __dp__.check_stopiteration()
-            break
-        else:
-            _dp_tmp_12 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_12:
-                yield __dp__.add(i, 1)
-x = __dp__.list(_dp_gen_9(__dp__.iter(range(5))))
 def _dp_gen_13(_dp_iter_14):
     _dp_iter_15 = __dp__.iter(_dp_iter_14)
     while True:
@@ -132,7 +119,7 @@ def _dp_gen_13(_dp_iter_14):
             _dp_tmp_16 = __dp__.eq(__dp__.mod(i, 2), 0)
             if _dp_tmp_16:
                 yield __dp__.add(i, 1)
-y = __dp__.set(_dp_gen_13(__dp__.iter(range(5))))
+x = __dp__.list(_dp_gen_13(__dp__.iter(range(5))))
 def _dp_gen_17(_dp_iter_18):
     _dp_iter_19 = __dp__.iter(_dp_iter_18)
     while True:
@@ -145,4 +132,17 @@ def _dp_gen_17(_dp_iter_18):
             _dp_tmp_20 = __dp__.eq(__dp__.mod(i, 2), 0)
             if _dp_tmp_20:
                 yield __dp__.add(i, 1)
-z = _dp_gen_17(__dp__.iter(range(5)))
+y = __dp__.set(_dp_gen_17(__dp__.iter(range(5))))
+def _dp_gen_21(_dp_iter_22):
+    _dp_iter_23 = __dp__.iter(_dp_iter_22)
+    while True:
+        try:
+            i = __dp__.next(_dp_iter_23)
+        except:
+            __dp__.check_stopiteration()
+            break
+        else:
+            _dp_tmp_24 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_24:
+                yield __dp__.add(i, 1)
+z = _dp_gen_21(__dp__.iter(range(5)))

--- a/src/transform/rewrite_class_def.rs
+++ b/src/transform/rewrite_class_def.rs
@@ -347,7 +347,9 @@ __dp__.setitem(_dp_prepare_ns, "__annotations__", _dp_class_annotations)
                 stub_def.body = py_stmt!("pass");
 
                 rewrite_method(&mut func_def, &class_name);
-                let helper_name = format!("_dp_meth_{}_{}", class_name, fn_name);
+                let helper_name = rewriter
+                    .context()
+                    .fresh(&format!("meth_{}_{}", class_name, fn_name));
 
                 let decorators = take(&mut func_def.decorator_list);
 
@@ -507,42 +509,42 @@ class C:
         return super().m()
 "#,
             r#"
-def _dp_meth_C_m():
+def _dp_meth_C_m_1():
     return super(C, None).m()
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_1 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_2)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
 
     def m():
         pass
-    __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
-    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
-    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
+    __dp__.setattr(m, "__code__", _dp_meth_C_m_1.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m_1.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m_1.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_C(ns)
-    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_4 = _dp_tmp_5
-    if _dp_tmp_4:
-        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_4 = _dp_tmp_6
-    if _dp_tmp_4:
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -33,41 +33,41 @@ class Foo:
     def method(self):
         return 1
 =
-def _dp_meth_Foo_method(self):
+def _dp_meth_Foo_method_1(self):
     return 1
 def _dp_ns_Foo(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_1 = "Foo"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = "Foo"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_2)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
     def method(self):
         pass
-    __dp__.setattr(method, "__code__", _dp_meth_Foo_method.__code__)
-    __dp__.setattr(method, "__doc__", _dp_meth_Foo_method.__doc__)
-    __dp__.setattr(method, "__annotations__", _dp_meth_Foo_method.__annotations__)
+    __dp__.setattr(method, "__code__", _dp_meth_Foo_method_1.__code__)
+    __dp__.setattr(method, "__doc__", _dp_meth_Foo_method_1.__doc__)
+    __dp__.setattr(method, "__annotations__", _dp_meth_Foo_method_1.__annotations__)
     __dp__.setattr(method, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".method"))
     __dp__.setitem(_dp_temp_ns, "method", method)
     __dp__.setitem(_dp_prepare_ns, "method", method)
 def _dp_make_class_Foo():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_3 = __dp__.prepare_class("Foo", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_4 = __dp__.prepare_class("Foo", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_Foo(ns)
-    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_4 = _dp_tmp_5
-    if _dp_tmp_4:
-        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_4 = _dp_tmp_6
-    if _dp_tmp_4:
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("Foo", bases, ns, **kwds)
 _dp_class_Foo = _dp_make_class_Foo()

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -287,41 +287,41 @@ class C:
     def m(self):
         return 1
 =
-def _dp_meth_C_m(self):
+def _dp_meth_C_m_1(self):
     return 1
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_1 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_2)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
     def m(self):
         pass
-    __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
-    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
-    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
+    __dp__.setattr(m, "__code__", _dp_meth_C_m_1.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m_1.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m_1.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_C(ns)
-    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_4 = _dp_tmp_5
-    if _dp_tmp_4:
-        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_4 = _dp_tmp_6
-    if _dp_tmp_4:
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -332,41 +332,41 @@ class C:
     def m(self):
         return super().m()
 =
-def _dp_meth_C_m(self):
+def _dp_meth_C_m_1(self):
     return super(C, self).m()
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_1 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_2)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
     def m(self):
         pass
-    __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
-    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
-    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
+    __dp__.setattr(m, "__code__", _dp_meth_C_m_1.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m_1.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m_1.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_C(ns)
-    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_4 = _dp_tmp_5
-    if _dp_tmp_4:
-        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_4 = _dp_tmp_6
-    if _dp_tmp_4:
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -377,42 +377,42 @@ class C:
     def m(z):
         return super().m()
 =
-def _dp_meth_C_m(z):
+def _dp_meth_C_m_1(z):
     return super(C, z).m()
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_1 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_2)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
 
     def m(z):
         pass
-    __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
-    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
-    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
+    __dp__.setattr(m, "__code__", _dp_meth_C_m_1.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m_1.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m_1.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_C(ns)
-    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_4 = _dp_tmp_5
-    if _dp_tmp_4:
-        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_4 = _dp_tmp_6
-    if _dp_tmp_4:
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -423,42 +423,42 @@ class C:
     def m():
         return super().m()
 =
-def _dp_meth_C_m():
+def _dp_meth_C_m_1():
     return super(C, None).m()
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_1 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_2)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
 
     def m():
         pass
-    __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
-    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
-    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
+    __dp__.setattr(m, "__code__", _dp_meth_C_m_1.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m_1.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m_1.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     __dp__.setitem(_dp_temp_ns, "m", m)
     __dp__.setitem(_dp_prepare_ns, "m", m)
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_C(ns)
-    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_4 = _dp_tmp_5
-    if _dp_tmp_4:
-        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_4 = _dp_tmp_6
-    if _dp_tmp_4:
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()
@@ -473,18 +473,18 @@ class C:
     def m(self):
         return self
 =
-def _dp_meth_C_m(self):
+def _dp_meth_C_m_1(self):
     return self
 def _dp_ns_C(_dp_prepare_ns):
     _dp_temp_ns = __dp__.dict()
     __dp__.setitem(_dp_temp_ns, "__module__", __name__)
     __dp__.setitem(_dp_prepare_ns, "__module__", __name__)
-    _dp_tmp_1 = "C"
-    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_1)
-    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_1)
+    _dp_tmp_2 = "C"
+    __dp__.setitem(_dp_temp_ns, "__qualname__", _dp_tmp_2)
+    __dp__.setitem(_dp_prepare_ns, "__qualname__", _dp_tmp_2)
     _dp_class_annotations = _dp_temp_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
     y = deco
     __dp__.setitem(_dp_temp_ns, "y", y)
@@ -493,9 +493,9 @@ def _dp_ns_C(_dp_prepare_ns):
     _dp_decorator_m_1 = other
     def m(self):
         pass
-    __dp__.setattr(m, "__code__", _dp_meth_C_m.__code__)
-    __dp__.setattr(m, "__doc__", _dp_meth_C_m.__doc__)
-    __dp__.setattr(m, "__annotations__", _dp_meth_C_m.__annotations__)
+    __dp__.setattr(m, "__code__", _dp_meth_C_m_1.__code__)
+    __dp__.setattr(m, "__doc__", _dp_meth_C_m_1.__doc__)
+    __dp__.setattr(m, "__annotations__", _dp_meth_C_m_1.__annotations__)
     __dp__.setattr(m, "__qualname__", __dp__.add(__dp__.getitem(_dp_prepare_ns, "__qualname__"), ".m"))
     m = _dp_decorator_m_0(_dp_decorator_m_1(m))
     __dp__.setitem(_dp_temp_ns, "m", m)
@@ -503,17 +503,17 @@ def _dp_ns_C(_dp_prepare_ns):
 def _dp_make_class_C():
     orig_bases = ()
     bases = __dp__.resolve_bases(orig_bases)
-    _dp_tmp_3 = __dp__.prepare_class("C", bases, None)
-    meta = __dp__.getitem(_dp_tmp_3, 0)
-    ns = __dp__.getitem(_dp_tmp_3, 1)
-    kwds = __dp__.getitem(_dp_tmp_3, 2)
+    _dp_tmp_4 = __dp__.prepare_class("C", bases, None)
+    meta = __dp__.getitem(_dp_tmp_4, 0)
+    ns = __dp__.getitem(_dp_tmp_4, 1)
+    kwds = __dp__.getitem(_dp_tmp_4, 2)
     _dp_ns_C(ns)
-    _dp_tmp_5 = __dp__.is_not(orig_bases, bases)
-    _dp_tmp_4 = _dp_tmp_5
-    if _dp_tmp_4:
-        _dp_tmp_6 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
-        _dp_tmp_4 = _dp_tmp_6
-    if _dp_tmp_4:
+    _dp_tmp_6 = __dp__.is_not(orig_bases, bases)
+    _dp_tmp_5 = _dp_tmp_6
+    if _dp_tmp_5:
+        _dp_tmp_7 = __dp__.not_(__dp__.contains(ns, "__orig_bases__"))
+        _dp_tmp_5 = _dp_tmp_7
+    if _dp_tmp_5:
         __dp__.setitem(ns, "__orig_bases__", orig_bases)
     return meta("C", bases, ns, **kwds)
 _dp_class_C = _dp_make_class_C()

--- a/tests/integration_modules/property_setter.py
+++ b/tests/integration_modules/property_setter.py
@@ -1,0 +1,11 @@
+class Example:
+    def __init__(self) -> None:
+        self._value = 0
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+    @value.setter
+    def value(self, value: int) -> None:
+        self._value = value

--- a/tests/test_property_setter_integration.py
+++ b/tests/test_property_setter_integration.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+def test_property_setter_roundtrip(run_integration_module) -> None:
+    """Property setters should round-trip values under the transform."""
+    with run_integration_module("property_setter") as module:
+        instance = module.Example()
+        instance.value = 5
+        assert instance.value == 5


### PR DESCRIPTION
## Summary
- generate per-accessor helper functions with `fresh()` so rewritten methods keep distinct bytecode objects
- update example desugaring output and transformation fixtures to reflect the new helper naming scheme
- enable the property setter integration test now that getters and setters no longer collide

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1c09e9dc48324beb47ffd4fa89eee