### PR TITLE
Implement iterator-based unpack handling for destructuring

### DIFF
--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -2,66 +2,74 @@ $ expr 001
 [a, *b, c] = d
 =
 
-a = __dp__.unpack(d, 0)
-b = __dp__.list(__dp__.getitem(d, __dp__.slice(1, __dp__.neg(1), None)))
-c = __dp__.unpack(d, __dp__.neg(1))
+_dp_tmp_1 = __dp__.unpack(d, (True, False, True))
+a = __dp__.getitem(_dp_tmp_1, 0)
+b = __dp__.list(__dp__.getitem(_dp_tmp_1, 1))
+c = __dp__.getitem(_dp_tmp_1, 2)
 
 
 $ expr 002
 [a, *b] = c
 =
 
-a = __dp__.unpack(c, 0)
-b = __dp__.list(__dp__.getitem(c, __dp__.slice(1, None, None)))
+_dp_tmp_1 = __dp__.unpack(c, (True, False))
+a = __dp__.getitem(_dp_tmp_1, 0)
+b = __dp__.list(__dp__.getitem(_dp_tmp_1, 1))
 
 
 $ expr 003
 [a, b] = c
 =
 
-a = __dp__.unpack(c, 0)
-b = __dp__.unpack(c, 1)
+_dp_tmp_1 = __dp__.unpack(c, (True, True))
+a = __dp__.getitem(_dp_tmp_1, 0)
+b = __dp__.getitem(_dp_tmp_1, 1)
 
 
 $ expr 004
 [*a, b] = c
 =
 
-a = __dp__.list(__dp__.getitem(c, __dp__.slice(0, __dp__.neg(1), None)))
-b = __dp__.unpack(c, __dp__.neg(1))
+_dp_tmp_1 = __dp__.unpack(c, (False, True))
+a = __dp__.list(__dp__.getitem(_dp_tmp_1, 0))
+b = __dp__.getitem(_dp_tmp_1, 1)
 
 
 $ expr 005
 a, b = c
 =
 
-a = __dp__.unpack(c, 0)
-b = __dp__.unpack(c, 1)
+_dp_tmp_1 = __dp__.unpack(c, (True, True))
+a = __dp__.getitem(_dp_tmp_1, 0)
+b = __dp__.getitem(_dp_tmp_1, 1)
 
 
 $ expr 006
 a, *b, c = d
 =
 
-a = __dp__.unpack(d, 0)
-b = __dp__.tuple(__dp__.getitem(d, __dp__.slice(1, __dp__.neg(1), None)))
-c = __dp__.unpack(d, __dp__.neg(1))
+_dp_tmp_1 = __dp__.unpack(d, (True, False, True))
+a = __dp__.getitem(_dp_tmp_1, 0)
+b = __dp__.tuple(__dp__.getitem(_dp_tmp_1, 1))
+c = __dp__.getitem(_dp_tmp_1, 2)
 
 
 $ expr 007
 *a, b = c
 =
 
-a = __dp__.tuple(__dp__.getitem(c, __dp__.slice(0, __dp__.neg(1), None)))
-b = __dp__.unpack(c, __dp__.neg(1))
+_dp_tmp_1 = __dp__.unpack(c, (False, True))
+a = __dp__.tuple(__dp__.getitem(_dp_tmp_1, 0))
+b = __dp__.getitem(_dp_tmp_1, 1)
 
 
 $ expr 008
 a, *b = c
 =
 
-a = __dp__.unpack(c, 0)
-b = __dp__.tuple(__dp__.getitem(c, __dp__.slice(1, None, None)))
+_dp_tmp_1 = __dp__.unpack(c, (True, False))
+a = __dp__.getitem(_dp_tmp_1, 0)
+b = __dp__.tuple(__dp__.getitem(_dp_tmp_1, 1))
 
 
 $ expr 009
@@ -304,14 +312,15 @@ def _dp_gen_1(_dp_iter_2):
     while True:
         try:
             _dp_tmp_4 = __dp__.next(_dp_iter_3)
-            k = __dp__.unpack(_dp_tmp_4, 0)
-            v = __dp__.unpack(_dp_tmp_4, 1)
+            _dp_tmp_5 = __dp__.unpack(_dp_tmp_4, (True, True))
+            k = __dp__.getitem(_dp_tmp_5, 0)
+            v = __dp__.getitem(_dp_tmp_5, 1)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_5 = __dp__.eq(__dp__.mod(k, 2), 0)
-            if _dp_tmp_5:
+            _dp_tmp_6 = __dp__.eq(__dp__.mod(k, 2), 0)
+            if _dp_tmp_6:
                 yield k, __dp__.add(v, 1)
 r = __dp__.dict(_dp_gen_1(__dp__.iter(items)))
 

--- a/src/transform/tests_rewrite_loop.txt
+++ b/src/transform/tests_rewrite_loop.txt
@@ -64,8 +64,9 @@ _dp_iter_1 = __dp__.iter(c)
 while True:
     try:
         _dp_tmp_2 = __dp__.next(_dp_iter_1)
-        a = __dp__.unpack(_dp_tmp_2, 0)
-        b = __dp__.tuple(__dp__.getitem(_dp_tmp_2, __dp__.slice(1, None, None)))
+        _dp_tmp_3 = __dp__.unpack(_dp_tmp_2, (True, False))
+        a = __dp__.getitem(_dp_tmp_3, 0)
+        b = __dp__.tuple(__dp__.getitem(_dp_tmp_3, 1))
     except:
         __dp__.check_stopiteration()
         break

--- a/src/transform/tests_rewrite_with.txt
+++ b/src/transform/tests_rewrite_with.txt
@@ -4,8 +4,9 @@ with a as b:
     c
 =
 _dp_tmp_2 = __dp__.with_enter(a)
-b = __dp__.unpack(_dp_tmp_2, 0)
-_dp_with_exit_1 = __dp__.unpack(_dp_tmp_2, 1)
+_dp_tmp_3 = __dp__.unpack(_dp_tmp_2, (True, True))
+b = __dp__.getitem(_dp_tmp_3, 0)
+_dp_with_exit_1 = __dp__.getitem(_dp_tmp_3, 1)
 try:
     c
 except:
@@ -19,12 +20,14 @@ with a as b, c as d:
     e
 =
 _dp_tmp_3 = __dp__.with_enter(a)
-b = __dp__.unpack(_dp_tmp_3, 0)
-_dp_with_exit_2 = __dp__.unpack(_dp_tmp_3, 1)
+_dp_tmp_4 = __dp__.unpack(_dp_tmp_3, (True, True))
+b = __dp__.getitem(_dp_tmp_4, 0)
+_dp_with_exit_2 = __dp__.getitem(_dp_tmp_4, 1)
 try:
-    _dp_tmp_4 = __dp__.with_enter(c)
-    d = __dp__.unpack(_dp_tmp_4, 0)
-    _dp_with_exit_1 = __dp__.unpack(_dp_tmp_4, 1)
+    _dp_tmp_5 = __dp__.with_enter(c)
+    _dp_tmp_6 = __dp__.unpack(_dp_tmp_5, (True, True))
+    d = __dp__.getitem(_dp_tmp_6, 0)
+    _dp_with_exit_1 = __dp__.getitem(_dp_tmp_6, 1)
     try:
         e
     except:
@@ -44,8 +47,9 @@ async def f():
 =
 async def f():
     _dp_tmp_2 = await __dp__.with_aenter(a)
-    b = __dp__.unpack(_dp_tmp_2, 0)
-    _dp_awith_exit_1 = __dp__.unpack(_dp_tmp_2, 1)
+    _dp_tmp_3 = __dp__.unpack(_dp_tmp_2, (True, True))
+    b = __dp__.getitem(_dp_tmp_3, 0)
+    _dp_awith_exit_1 = __dp__.getitem(_dp_tmp_3, 1)
     try:
         c
     except:
@@ -59,10 +63,12 @@ with a as (b, *c):
     pass
 =
 _dp_tmp_2 = __dp__.with_enter(a)
-_dp_tmp_3 = __dp__.unpack(_dp_tmp_2, 0)
-b = __dp__.unpack(_dp_tmp_3, 0)
-c = __dp__.tuple(__dp__.getitem(_dp_tmp_3, __dp__.slice(1, None, None)))
-_dp_with_exit_1 = __dp__.unpack(_dp_tmp_2, 1)
+_dp_tmp_3 = __dp__.unpack(_dp_tmp_2, (True, True))
+_dp_tmp_4 = __dp__.getitem(_dp_tmp_3, 0)
+_dp_tmp_5 = __dp__.unpack(_dp_tmp_4, (True, False))
+b = __dp__.getitem(_dp_tmp_5, 0)
+c = __dp__.tuple(__dp__.getitem(_dp_tmp_5, 1))
+_dp_with_exit_1 = __dp__.getitem(_dp_tmp_3, 1)
 try:
     pass
 except:

--- a/tests/integration_modules/map_unpack.py
+++ b/tests/integration_modules/map_unpack.py
@@ -1,0 +1,6 @@
+try:
+    A, B, C = map(int, (1, 2, 3))
+except Exception as exc:  # pragma: no cover - reproduction module
+    RESULT = ("error", type(exc).__name__, str(exc))
+else:  # pragma: no cover
+    RESULT = ("ok", (A, B, C))

--- a/tests/test_map_unpack_integration.py
+++ b/tests/test_map_unpack_integration.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.integration
+def test_unpacking_iterator_succeeds(run_integration_module):
+    with run_integration_module("map_unpack") as module:
+        assert module.RESULT[0] == "ok"
+        assert module.RESULT[1] == (1, 2, 3)


### PR DESCRIPTION
## Summary
- reimplement `__dp__.unpack` using iterator semantics that support starred targets via a boolean spec
- update assignment lowering to request unpack specs and reuse the unpacked tuple for element extraction
- refresh transform fixtures and integration coverage to exercise iterator unpacking

## Testing
- pytest tests
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d33a2bbbd08324af2476465bfc7435