### PR TITLE
Track function-local class helpers inside their defining scope

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -10,8 +10,8 @@ def _dp_ns_A(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "A")
     _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_6 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_6:
+    _dp_tmp_8 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_8:
         _dp_class_annotations = __dp__.dict()
     _dp_var_b_1 = _dp_add_binding("b", 1)
 
@@ -26,10 +26,10 @@ def _dp_ns_A(_dp_prepare_ns, _dp_add_binding):
     _dp_var_c_3 = _dp_add_binding("c", _dp_var_c_3)
 
     async def _dp_var_test_aiter_4(self):
-        _dp_iter_7 = __dp__.iter(range(10))
+        _dp_iter_6 = __dp__.iter(range(10))
         while True:
             try:
-                i = __dp__.next(_dp_iter_7)
+                i = __dp__.next(_dp_iter_6)
             except:
                 __dp__.check_stopiteration()
                 break
@@ -39,10 +39,10 @@ def _dp_ns_A(_dp_prepare_ns, _dp_add_binding):
     _dp_var_test_aiter_4 = _dp_add_binding("test_aiter", _dp_var_test_aiter_4)
 
     async def _dp_var_d_5(self):
-        _dp_iter_8 = __dp__.aiter(self.test_aiter())
+        _dp_iter_7 = __dp__.aiter(self.test_aiter())
         while True:
             try:
-                i = await __dp__.anext(_dp_iter_8)
+                i = await __dp__.anext(_dp_iter_7)
             except:
                 __dp__.acheck_stopiteration()
                 break

--- a/src/transform/context.rs
+++ b/src/transform/context.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 use super::Options;
 
@@ -23,6 +23,7 @@ impl Namer {
 pub struct Context {
     pub namer: Namer,
     pub options: Options,
+    function_stack: RefCell<Vec<String>>,
 }
 
 impl Context {
@@ -30,10 +31,23 @@ impl Context {
         Self {
             namer: Namer::new(),
             options,
+            function_stack: RefCell::new(Vec::new()),
         }
     }
 
     pub fn fresh(&self, name: &str) -> String {
         self.namer.fresh(name)
+    }
+
+    pub fn push_function(&self, qualname: String) {
+        self.function_stack.borrow_mut().push(qualname);
+    }
+
+    pub fn current_function_qualname(&self) -> Option<String> {
+        self.function_stack.borrow().last().cloned()
+    }
+
+    pub fn pop_function(&self) {
+        self.function_stack.borrow_mut().pop();
     }
 }

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -275,3 +275,76 @@ def _dp_ns_Outer(_dp_prepare_ns, _dp_add_binding):
     Inner = _dp_add_binding("Inner", _dp_tmp_2)
 _dp_class_Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
 Outer = _dp_class_Outer
+$ function local class remains scoped
+
+class Example:
+    def trigger(self):
+        class Token:
+            pass
+        return Token
+=
+def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
+    _dp_add_binding("__module__", __name__)
+    _dp_add_binding("__qualname__", "Example")
+    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
+        _dp_class_annotations = __dp__.dict()
+
+    def _dp_var_trigger_1(self):
+
+        def _dp_ns_Example_trigger__locals__Token(_dp_prepare_ns, _dp_add_binding):
+            _dp_add_binding("__module__", __name__)
+            _dp_add_binding("__qualname__", "Example.trigger.<locals>.Token")
+            _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
+            _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+            if _dp_tmp_2:
+                _dp_class_annotations = __dp__.dict()
+        _dp_class_Example_trigger__locals__Token = __dp__.create_class("Token", _dp_ns_Example_trigger__locals__Token, (), None)
+        Token = _dp_class_Example_trigger__locals__Token
+        return Token
+    __dp__.setattr(_dp_var_trigger_1, "__name__", "trigger")
+    _dp_var_trigger_1 = _dp_add_binding("trigger", _dp_var_trigger_1)
+_dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
+Example = _dp_class_Example
+$ function local class nested in if
+
+class Example:
+    def trigger(self, flag):
+        if flag:
+            class Token:
+                pass
+            return Token
+        return None
+=
+def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
+    _dp_add_binding("__module__", __name__)
+    _dp_add_binding("__qualname__", "Example")
+    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
+    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_3:
+        _dp_class_annotations = __dp__.dict()
+
+    def _dp_var_trigger_1(self, flag):
+
+        if flag:
+            def _dp_ns_Example_trigger__locals__Token(_dp_prepare_ns, _dp_add_binding):
+                _dp_add_binding("__module__", __name__)
+                _dp_add_binding("__qualname__", "Example.trigger.<locals>.Token")
+                _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
+                _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+                if _dp_tmp_2:
+                    _dp_class_annotations = __dp__.dict()
+            _dp_class_Example_trigger__locals__Token = __dp__.create_class(
+                "Token",
+                _dp_ns_Example_trigger__locals__Token,
+                (),
+                None,
+            )
+            Token = _dp_class_Example_trigger__locals__Token
+            return Token
+        return None
+    __dp__.setattr(_dp_var_trigger_1, "__name__", "trigger")
+    _dp_var_trigger_1 = _dp_add_binding("trigger", _dp_var_trigger_1)
+_dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
+Example = _dp_class_Example


### PR DESCRIPTION
## Summary
- track the current function scope in the transform context so nested class helpers derive the correct qualname
- reuse the standard class rewrite while rewriting function bodies, allowing class helpers to stay nested under conditionals
- extend transform fixtures and the desugared example to cover in-function classes and refreshed helper numbering

## Testing
- cargo test
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68d330cba63883249d7b0f7948da5c06