### PR TITLE
Refactor class annotation handling at end of namespace rewrite

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -9,10 +9,6 @@ add = _dp_decorator_add_0(_dp_decorator_add_1(add))
 def _dp_ns_A(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "A")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_8 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_8:
-        _dp_class_annotations = __dp__.dict()
     _dp_var_b_1 = _dp_add_binding("b", 1)
 
     def _dp_var___init___2(self):
@@ -61,42 +57,42 @@ c = ff()
 __dp__.delattr(c.a, "b")
 __dp__.delitem(c.a.arr, 0)
 del c
-def _dp_gen_9(_dp_iter_10):
-    _dp_iter_11 = __dp__.iter(_dp_iter_10)
+def _dp_gen_8(_dp_iter_9):
+    _dp_iter_10 = __dp__.iter(_dp_iter_9)
     while True:
         try:
-            i = __dp__.next(_dp_iter_11)
+            i = __dp__.next(_dp_iter_10)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_12 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_12:
+            _dp_tmp_11 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_11:
                 yield __dp__.add(i, 1)
-x = __dp__.list(_dp_gen_9(__dp__.iter(range(5))))
-def _dp_gen_13(_dp_iter_14):
-    _dp_iter_15 = __dp__.iter(_dp_iter_14)
+x = __dp__.list(_dp_gen_8(__dp__.iter(range(5))))
+def _dp_gen_12(_dp_iter_13):
+    _dp_iter_14 = __dp__.iter(_dp_iter_13)
     while True:
         try:
-            i = __dp__.next(_dp_iter_15)
+            i = __dp__.next(_dp_iter_14)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_16 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_16:
+            _dp_tmp_15 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_15:
                 yield __dp__.add(i, 1)
-y = __dp__.set(_dp_gen_13(__dp__.iter(range(5))))
-def _dp_gen_17(_dp_iter_18):
-    _dp_iter_19 = __dp__.iter(_dp_iter_18)
+y = __dp__.set(_dp_gen_12(__dp__.iter(range(5))))
+def _dp_gen_16(_dp_iter_17):
+    _dp_iter_18 = __dp__.iter(_dp_iter_17)
     while True:
         try:
-            i = __dp__.next(_dp_iter_19)
+            i = __dp__.next(_dp_iter_18)
         except:
             __dp__.check_stopiteration()
             break
         else:
-            _dp_tmp_20 = __dp__.eq(__dp__.mod(i, 2), 0)
-            if _dp_tmp_20:
+            _dp_tmp_19 = __dp__.eq(__dp__.mod(i, 2), 0)
+            if _dp_tmp_19:
                 yield __dp__.add(i, 1)
-z = _dp_gen_17(__dp__.iter(range(5)))
+z = _dp_gen_16(__dp__.iter(range(5)))

--- a/src/transform/rewrite_class_def.rs
+++ b/src/transform/rewrite_class_def.rs
@@ -7,7 +7,7 @@ use crate::transform::rewrite_decorator;
 use crate::{py_expr, py_stmt};
 use ruff_python_ast::{self as ast, Expr, ExprContext, Stmt};
 use ruff_text_size::TextRange;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::mem::take;
 
 fn class_ident_from_qualname(qualname: &str) -> String {
@@ -369,7 +369,7 @@ pub fn rewrite(
     ));
 
     let mut original_body = body;
-    let mut annotations = VecDeque::from(annotations);
+    let has_class_annotations = !annotations.is_empty();
     if let Some(first_stmt) = original_body.first_mut() {
         if let Stmt::Expr(ast::StmtExpr { value, .. }) = first_stmt {
             if let Expr::StringLiteral(_) = value.as_ref() {
@@ -378,111 +378,95 @@ pub fn rewrite(
             }
         }
     }
-    ns_body.extend(py_stmt!(
-        r#"
+
+    for stmt in original_body.into_iter() {
+        match stmt {
+            Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
+                if targets.len() == 1 {
+                    if let Expr::Name(ast::ExprName { id, .. }) = &targets[0] {
+                        let replacement_name = id.as_str().to_string();
+                        let (stmts, value_expr) = rewriter.maybe_placeholder_within(*value);
+                        ns_body.extend(stmts);
+                        add_class_binding(&mut ns_body, replacement_name.as_str(), value_expr);
+                    }
+                } else {
+                    let (mut stmts, shared_value) = rewriter.maybe_placeholder_within(*value);
+                    ns_body.append(&mut stmts);
+                    for target in targets {
+                        if let Expr::Name(ast::ExprName { id, .. }) = target {
+                            let replacement_name = id.as_str().to_string();
+                            add_class_binding(
+                                &mut ns_body,
+                                replacement_name.as_str(),
+                                shared_value.clone(),
+                            );
+                        }
+                    }
+                }
+            }
+            Stmt::FunctionDef(mut func_def) => {
+                let fn_name = func_def.name.id.to_string();
+                let original_fn_name =
+                    lookup_original_name(&replacement_to_original, fn_name.as_str());
+
+                rewrite_method(
+                    &mut func_def,
+                    &class_name,
+                    &class_qualname,
+                    original_fn_name.as_str(),
+                    rewriter,
+                );
+
+                let decorators = take(&mut func_def.decorator_list);
+
+                let mut method_stmts = Vec::new();
+                method_stmts.push(Stmt::FunctionDef(func_def));
+                method_stmts.extend(py_stmt!(
+                    "{fn_name:id}.__name__ = {original_name:literal}",
+                    fn_name = fn_name.as_str(),
+                    original_name = original_fn_name.as_str(),
+                ));
+
+                let method_stmts = rewrite_decorator::rewrite(
+                    decorators,
+                    fn_name.as_str(),
+                    method_stmts,
+                    rewriter.context(),
+                )
+                .into_statements();
+
+                ns_body.extend(method_stmts);
+                ns_body.extend(py_stmt!(
+                    "{fn_name:id} = _dp_add_binding({name:literal}, {value:expr})",
+                    fn_name = fn_name.as_str(),
+                    name = original_fn_name.as_str(),
+                    value = py_expr!("{fn_name:id}", fn_name = fn_name.as_str()),
+                ));
+            }
+            Stmt::ClassDef(_) => {
+                unreachable!("nested classes should be collected before rewriting")
+            }
+            other => ns_body.push(other),
+        }
+    }
+
+    if has_class_annotations {
+        ns_body.extend(py_stmt!(
+            r#"
 _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
 if _dp_class_annotations is None:
     _dp_class_annotations = __dp__.dict()
 "#
-    ));
+        ));
 
-    let mut has_class_annotations = false;
+        ns_body.extend(py_stmt!(
+            "_dp_add_binding({name:literal}, _dp_class_annotations)",
+            name = "__annotations__",
+        ));
 
-    for (index, stmt) in original_body.into_iter().enumerate() {
-        let has_annotation = annotations
-            .front()
-            .map(|(ann_index, _, _)| *ann_index == index)
-            .unwrap_or(false);
-
-        let skip_stmt = has_annotation && matches!(stmt, Stmt::Pass(_));
-
-        if !skip_stmt {
-            match stmt {
-                Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
-                    if targets.len() == 1 {
-                        if let Expr::Name(ast::ExprName { id, .. }) = &targets[0] {
-                            let replacement_name = id.as_str().to_string();
-                            let (stmts, value_expr) = rewriter.maybe_placeholder_within(*value);
-                            ns_body.extend(stmts);
-                            add_class_binding(&mut ns_body, replacement_name.as_str(), value_expr);
-                        }
-                    } else {
-                        let (mut stmts, shared_value) = rewriter.maybe_placeholder_within(*value);
-                        ns_body.append(&mut stmts);
-                        for target in targets {
-                            if let Expr::Name(ast::ExprName { id, .. }) = target {
-                                let replacement_name = id.as_str().to_string();
-                                add_class_binding(
-                                    &mut ns_body,
-                                    replacement_name.as_str(),
-                                    shared_value.clone(),
-                                );
-                            }
-                        }
-                    }
-                }
-                Stmt::FunctionDef(mut func_def) => {
-                    let fn_name = func_def.name.id.to_string();
-                    let original_fn_name =
-                        lookup_original_name(&replacement_to_original, fn_name.as_str());
-
-                    rewrite_method(
-                        &mut func_def,
-                        &class_name,
-                        &class_qualname,
-                        original_fn_name.as_str(),
-                        rewriter,
-                    );
-
-                    let decorators = take(&mut func_def.decorator_list);
-
-                    let mut method_stmts = Vec::new();
-                    method_stmts.push(Stmt::FunctionDef(func_def));
-                    method_stmts.extend(py_stmt!(
-                        "{fn_name:id}.__name__ = {original_name:literal}",
-                        fn_name = fn_name.as_str(),
-                        original_name = original_fn_name.as_str(),
-                    ));
-
-                    let method_stmts = rewrite_decorator::rewrite(
-                        decorators,
-                        fn_name.as_str(),
-                        method_stmts,
-                        rewriter.context(),
-                    )
-                    .into_statements();
-
-                    ns_body.extend(method_stmts);
-                    ns_body.extend(py_stmt!(
-                        "{fn_name:id} = _dp_add_binding({name:literal}, {value:expr})",
-                        fn_name = fn_name.as_str(),
-                        name = original_fn_name.as_str(),
-                        value = py_expr!("{fn_name:id}", fn_name = fn_name.as_str()),
-                    ));
-                }
-                Stmt::ClassDef(_) => {
-                    unreachable!("nested classes should be collected before rewriting")
-                }
-                other => ns_body.push(other),
-            }
-        }
-
-        while annotations
-            .front()
-            .map(|(ann_index, _, _)| *ann_index == index)
-            .unwrap_or(false)
-        {
-            let (_, replacement_name, annotation) = annotations.pop_front().unwrap();
+        for (_, replacement_name, annotation) in annotations {
             let original_name =
                 lookup_original_name(&replacement_to_original, replacement_name.as_str());
-
-            if !has_class_annotations {
-                ns_body.extend(py_stmt!(
-                    "_dp_add_binding({name:literal}, _dp_class_annotations)",
-                    name = "__annotations__",
-                ));
-                has_class_annotations = true;
-            }
 
             let (ann_stmts, annotation_expr) = rewriter.maybe_placeholder_within(annotation);
             ns_body.extend(ann_stmts);
@@ -584,10 +568,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
-        _dp_class_annotations = __dp__.dict()
 
     def _dp_var_m_1():
         return super(C, None).m()

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -35,11 +35,6 @@ class Foo:
 def _dp_ns_Foo(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "Foo")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_3:
-        _dp_class_annotations = __dp__.dict()
-
     def _dp_var_method_2(self):
         return 1
     __dp__.setattr(_dp_var_method_2, "__name__", "method")

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -6,10 +6,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
-        _dp_class_annotations = __dp__.dict()
     _dp_var_x_1 = _dp_add_binding("x", 1)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
@@ -22,13 +18,13 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
+    _dp_var_y_2 = _dp_add_binding("y", 1)
     _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
     _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
     if _dp_tmp_3:
         _dp_class_annotations = __dp__.dict()
     _dp_add_binding("__annotations__", _dp_class_annotations)
     __dp__.setitem(_dp_class_annotations, "x", int)
-    _dp_var_y_2 = _dp_add_binding("y", 1)
     __dp__.setitem(_dp_class_annotations, "y", str)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
@@ -40,10 +36,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
-        _dp_class_annotations = __dp__.dict()
     _dp_var_x_1 = _dp_add_binding("x", x)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
@@ -75,10 +67,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_3:
-        _dp_class_annotations = __dp__.dict()
     _dp_var_x_1 = _dp_add_binding("x", 1)
     _dp_var_y_2 = _dp_add_binding("y", _dp_var_x_1)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
@@ -91,10 +79,6 @@ class C(B):
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_1:
-        _dp_class_annotations = __dp__.dict()
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (B,), None)
 C = _dp_class_C
 $ lowers with docstring and keywords
@@ -106,10 +90,6 @@ class C(B, metaclass=Meta, kw=1):
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_3:
-        _dp_class_annotations = __dp__.dict()
     _dp_tmp_2 = 'doc'
     __doc__ = _dp_add_binding("__doc__", _dp_tmp_2)
     _dp_var_x_1 = _dp_add_binding("x", 2)
@@ -124,10 +104,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
-        _dp_class_annotations = __dp__.dict()
 
     def _dp_var_m_1(self):
         return 1
@@ -144,10 +120,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
-        _dp_class_annotations = __dp__.dict()
 
     def _dp_var_m_1(self):
         return super(C, self).m()
@@ -164,10 +136,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
-        _dp_class_annotations = __dp__.dict()
 
     def _dp_var_m_1(z):
         return super(C, z).m()
@@ -184,10 +152,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
-        _dp_class_annotations = __dp__.dict()
 
     def _dp_var_m_1():
         return super(C, None).m()
@@ -208,10 +172,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_3:
-        _dp_class_annotations = __dp__.dict()
     _dp_var_y_1 = _dp_add_binding("y", deco)
     _dp_decorator__dp_var_m_2_0 = decorator(_dp_var_y_1)
     _dp_decorator__dp_var_m_2_1 = other
@@ -235,10 +195,6 @@ class C:
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_4 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_4:
-        _dp_class_annotations = __dp__.dict()
     _dp_var_a_1 = _dp_add_binding("a", 1)
     _dp_var_b_2 = _dp_add_binding("b", _dp_var_a_1)
 
@@ -259,17 +215,9 @@ class Outer:
 def _dp_ns_Outer_Inner(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "Outer.Inner")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_3:
-        _dp_class_annotations = __dp__.dict()
 def _dp_ns_Outer(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "Outer")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_4 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_4:
-        _dp_class_annotations = __dp__.dict()
     _dp_var_x_1 = _dp_add_binding("x", 1)
     _dp_tmp_2 = __dp__.create_class("Inner", _dp_ns_Outer_Inner, (_dp_var_x_1,), None)
     Inner = _dp_add_binding("Inner", _dp_tmp_2)
@@ -286,20 +234,12 @@ class Example:
 def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "Example")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_3:
-        _dp_class_annotations = __dp__.dict()
 
     def _dp_var_trigger_1(self):
 
         def _dp_ns_Example_trigger__locals__Token(_dp_prepare_ns, _dp_add_binding):
             _dp_add_binding("__module__", __name__)
             _dp_add_binding("__qualname__", "Example.trigger.<locals>.Token")
-            _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-            _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-            if _dp_tmp_2:
-                _dp_class_annotations = __dp__.dict()
         _dp_class_Example_trigger__locals__Token = __dp__.create_class("Token", _dp_ns_Example_trigger__locals__Token, (), None)
         Token = _dp_class_Example_trigger__locals__Token
         return Token
@@ -320,10 +260,6 @@ class Example:
 def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "Example")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_3 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_3:
-        _dp_class_annotations = __dp__.dict()
 
     def _dp_var_trigger_1(self, flag):
 
@@ -331,10 +267,6 @@ def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
             def _dp_ns_Example_trigger__locals__Token(_dp_prepare_ns, _dp_add_binding):
                 _dp_add_binding("__module__", __name__)
                 _dp_add_binding("__qualname__", "Example.trigger.<locals>.Token")
-                _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-                _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-                if _dp_tmp_2:
-                    _dp_class_annotations = __dp__.dict()
             _dp_class_Example_trigger__locals__Token = __dp__.create_class(
                 "Token",
                 _dp_ns_Example_trigger__locals__Token,

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -30,10 +30,6 @@ _dp_decorator__dp_class_C_0 = dec
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_1:
-        _dp_class_annotations = __dp__.dict()
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 _dp_class_C = _dp_decorator__dp_class_C_0(_dp_class_C)
 C = _dp_class_C
@@ -49,10 +45,6 @@ _dp_decorator__dp_class_C_1 = dec1
 def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
     _dp_add_binding("__module__", __name__)
     _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_1:
-        _dp_class_annotations = __dp__.dict()
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 _dp_class_C = _dp_decorator__dp_class_C_0(_dp_decorator__dp_class_C_1(_dp_class_C))
 C = _dp_class_C


### PR DESCRIPTION
## Summary
- simplify the class namespace rewrite by processing annotations after the body traversal instead of tracking them statement-by-statement
- refresh the class rewrite, decorator, and module fixtures so helper annotations only appear when needed and after the rewritten body
- regenerate the example desugaring output to align with the updated transform

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d345a57bfc8324b1e16cddf8beeba0