### PR TITLE
Remove desugared output capture from nested super xfail

### DIFF
--- a/tests/test_cpython_transform_failures.py
+++ b/tests/test_cpython_transform_failures.py
@@ -159,6 +159,32 @@ class Container:
             container.probe()
 
 
+@pytest.mark.xfail(reason="Nested classes defined inside methods lose their __class__ binding; CPython's test_smtplib depends on this working")
+def test_nested_class_super_preserves_class_cell(tmp_path: Path) -> None:
+    source = r"""
+class Base:
+    def probe(self):
+        return "sentinel"
+
+
+class Container:
+    def build(self):
+        class Derived(Base):
+            def probe(self):
+                return super().probe()
+
+        instance = Derived()
+        return instance.probe()
+"""
+
+    module_name = "nested_super"
+
+    with transformed_module(tmp_path, module_name, source) as module:
+        result = module.Container().build()
+
+    assert result == "sentinel"
+
+
 @pytest.mark.xfail(reason="Tuple unpacking should raise ValueError; CPython's test_turtle relies on this")
 def test_tuple_unpacking_raises_value_error(tmp_path: Path) -> None:
     source = r"""


### PR DESCRIPTION
## Summary
- drop the subprocess-based desugared output assertion from the nested super xfail test and rely solely on the runtime expectation

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d33a33db948324ac71294032d74ce2