### PR TITLE
Fix chained comparison evaluation

### DIFF
--- a/src/transform/driver.rs
+++ b/src/transform/driver.rs
@@ -323,7 +323,7 @@ else:
             }
             Expr::Compare(compare) => {
                 let tmp = self.ctx.fresh("tmp");
-                let stmts = expr_compare_to_stmts(tmp.as_str(), compare);
+                let stmts = expr_compare_to_stmts(self.ctx, tmp.as_str(), compare);
                 self.buf.extend(stmts);
                 py_expr!("{tmp:id}", tmp = tmp.as_str())
             }

--- a/src/transform/rewrite_class_def.rs
+++ b/src/transform/rewrite_class_def.rs
@@ -303,9 +303,8 @@ fn rewrite_method(
 
     let method_qualname = format!("{class_qualname}.{original_method_name}");
     let body = take(&mut func_def.body);
-    func_def.body = rewriter.with_function_scope(method_qualname, |rewriter| {
-        rewriter.rewrite_block(body)
-    });
+    func_def.body =
+        rewriter.with_function_scope(method_qualname, |rewriter| rewriter.rewrite_block(body));
 }
 
 pub fn rewrite(

--- a/src/transform/tests_rewrite_expr_to_stmt.txt
+++ b/src/transform/tests_rewrite_expr_to_stmt.txt
@@ -33,20 +33,23 @@ $ rewrites chained compare assignment
 
 x = a < b < c
 =
-_dp_tmp_1 = __dp__.lt(a, b)
+_dp_compare_2 = b
+_dp_tmp_1 = __dp__.lt(a, _dp_compare_2)
 if _dp_tmp_1:
-    _dp_tmp_1 = __dp__.lt(b, c)
+    _dp_tmp_1 = __dp__.lt(_dp_compare_2, c)
 x = _dp_tmp_1
 
 $ rewrites multi chained compare assignment
 
 x = a < b <= c < d
 =
-_dp_tmp_1 = __dp__.lt(a, b)
+_dp_compare_2 = b
+_dp_tmp_1 = __dp__.lt(a, _dp_compare_2)
 if _dp_tmp_1:
-    _dp_tmp_1 = __dp__.le(b, c)
+    _dp_compare_3 = c
+    _dp_tmp_1 = __dp__.le(_dp_compare_2, _dp_compare_3)
 if _dp_tmp_1:
-    _dp_tmp_1 = __dp__.lt(c, d)
+    _dp_tmp_1 = __dp__.lt(_dp_compare_3, d)
 x = _dp_tmp_1
 
 $ rewrites lambda in return stmt


### PR DESCRIPTION
## Summary
- cache intermediate comparators when rewriting chained comparisons so side-effecting expressions run once
- wire the compare rewrite through the transform context and update fixtures to document the new temporary assignments
- promote the chained comparison regression test to a passing case

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36a27f09883248ee849eb302f4323