### PR TITLE
Refine class namespace rewriting semantics

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -6,18 +6,18 @@ _dp_decorator_add_1 = bar(1, 2)
 def add(a, b):
     return __dp__.add(a, b)
 add = _dp_decorator_add_0(_dp_decorator_add_1(add))
-def _dp_ns_A(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "A")
-    b = _dp_add_binding("b", 1)
+def _dp_ns_A(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "A")
+    __dp__.setitem(_dp_ns, "b", 1)
 
     def __init__(self):
         __dp__.setattr(self, "arr", __dp__.list((1, 2, 3)))
-    __init__ = _dp_add_binding("__init__", __init__)
+    __dp__.setitem(_dp_ns, "__init__", __init__)
 
     def c(self, d):
         return add(d, 2)
-    c = _dp_add_binding("c", c)
+    __dp__.setitem(_dp_ns, "c", c)
 
     async def test_aiter(self):
         _dp_iter_1 = __dp__.iter(range(10))
@@ -29,7 +29,7 @@ def _dp_ns_A(_dp_prepare_ns, _dp_add_binding):
                 break
             else:
                 yield i
-    test_aiter = _dp_add_binding("test_aiter", test_aiter)
+    __dp__.setitem(_dp_ns, "test_aiter", test_aiter)
 
     async def d(self):
         _dp_iter_2 = __dp__.aiter(self.test_aiter())
@@ -41,7 +41,7 @@ def _dp_ns_A(_dp_prepare_ns, _dp_add_binding):
                 break
             else:
                 print(i)
-    d = _dp_add_binding("d", d)
+    __dp__.setitem(_dp_ns, "d", d)
 _dp_class_A = __dp__.create_class("A", _dp_ns_A, (), None)
 A = _dp_class_A
 def ff():

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -2,7 +2,6 @@ $ strips type alias statement
 
 type Alias = int
 =
-
 $ strips type aliases in if branches
 
 if True:
@@ -32,12 +31,12 @@ class Foo:
     def method(self):
         return 1
 =
-def _dp_ns_Foo(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Foo")
+def _dp_ns_Foo(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Foo")
 
     def method(self):
         return 1
-    method = _dp_add_binding("method", method)
+    __dp__.setitem(_dp_ns, "method", method)
 _dp_class_Foo = __dp__.create_class("Foo", _dp_ns_Foo, (), None)
 Foo = _dp_class_Foo

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -3,10 +3,10 @@ $ lowers simple class
 class C:
     x = 1
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
-    x = _dp_add_binding("x", 1)
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_ns, "x", 1)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ collects class annotations
@@ -15,15 +15,15 @@ class C:
     x: int
     y: str = 1
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
-    y = _dp_add_binding("y", 1)
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_ns, "y", 1)
+    _dp_class_annotations = _dp_ns.get("__annotations__")
     _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
     if _dp_tmp_1:
         _dp_class_annotations = __dp__.dict()
-    _dp_add_binding("__annotations__", _dp_class_annotations)
+    __dp__.setitem(_dp_ns, "__annotations__", _dp_class_annotations)
     __dp__.setitem(_dp_class_annotations, "x", int)
     __dp__.setitem(_dp_class_annotations, "y", str)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
@@ -33,11 +33,10 @@ $ captures outer reference
 class C:
     x = x
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
-    _dp_tmp_1 = __dp__.global_(globals(), "x")
-    x = _dp_add_binding("x", _dp_tmp_1)
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_ns, "x", x)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ captures names used in annotations
@@ -48,16 +47,15 @@ class C:
     x: T
 =
 T = object()
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
-    _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
-    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
-    if _dp_tmp_2:
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
+    _dp_class_annotations = _dp_ns.get("__annotations__")
+    _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_1:
         _dp_class_annotations = __dp__.dict()
-    _dp_add_binding("__annotations__", _dp_class_annotations)
-    _dp_tmp_1 = __dp__.global_(globals(), "T")
-    __dp__.setitem(_dp_class_annotations, "x", _dp_tmp_1)
+    __dp__.setitem(_dp_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setitem(_dp_class_annotations, "x", T)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ preserves class locals for references
@@ -66,11 +64,11 @@ class C:
     x = 1
     y = x
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
-    x = _dp_add_binding("x", 1)
-    y = _dp_add_binding("y", x)
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_ns, "x", 1)
+    __dp__.setitem(_dp_ns, "y", __dp__.getitem(_dp_ns, "x"))
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ lowers inherits
@@ -78,9 +76,9 @@ $ lowers inherits
 class C(B):
     pass
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (B,), None)
 C = _dp_class_C
 $ lowers with docstring and keywords
@@ -89,12 +87,12 @@ class C(B, metaclass=Meta, kw=1):
     'doc'
     x = 2
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
     _dp_tmp_1 = 'doc'
-    __doc__ = _dp_add_binding("__doc__", _dp_tmp_1)
-    x = _dp_add_binding("x", 2)
+    __dp__.setitem(_dp_ns, "__doc__", _dp_tmp_1)
+    __dp__.setitem(_dp_ns, "x", 2)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (B,), __dp__.dict((("metaclass", Meta), ("kw", 1))))
 C = _dp_class_C
 $ lowers method
@@ -103,13 +101,13 @@ class C:
     def m(self):
         return 1
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
 
     def m(self):
         return 1
-    m = _dp_add_binding("m", m)
+    __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ rewrites super and class
@@ -118,13 +116,13 @@ class C:
     def m(self):
         return super().m()
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
 
     def m(self):
         return super(C, self).m()
-    m = _dp_add_binding("m", m)
+    __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ rewrites super uses first arg
@@ -133,13 +131,13 @@ class C:
     def m(z):
         return super().m()
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
 
     def m(z):
         return super(C, z).m()
-    m = _dp_add_binding("m", m)
+    __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ rewrites super without receiver
@@ -148,13 +146,13 @@ class C:
     def m():
         return super().m()
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
 
     def m():
         return super(C, None).m()
-    m = _dp_add_binding("m", m)
+    __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ applies decorators in namespace
@@ -167,18 +165,17 @@ class C:
     def m(self):
         return self
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
-    _dp_tmp_1 = __dp__.global_(globals(), "deco")
-    y = _dp_add_binding("y", _dp_tmp_1)
-    _dp_decorator_m_0 = __dp__.global_(globals(), "decorator")(y)
-    _dp_decorator_m_1 = __dp__.global_(globals(), "other")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_ns, "y", deco)
+    _dp_decorator_m_0 = decorator(__dp__.getitem(_dp_ns, "y"))
+    _dp_decorator_m_1 = other
 
     def m(self):
         return self
-    m = _dp_decorator_m_0(_dp_decorator_m_1(m))
-    m = _dp_add_binding("m", m)
+    __dp__.setitem(_dp_ns, "m", _dp_decorator_m_0(_dp_decorator_m_1(m)))
+    __dp__.setitem(_dp_ns, "m", __dp__.getitem(_dp_ns, "m"))
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ renames class stores and uses
@@ -190,15 +187,15 @@ class C:
     def f(self, value: b = a):
         return value
 =
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
-    a = _dp_add_binding("a", 1)
-    b = _dp_add_binding("b", a)
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_ns, "a", 1)
+    __dp__.setitem(_dp_ns, "b", __dp__.getitem(_dp_ns, "a"))
 
-    def f(self, value: b=a):
+    def f(self, value: __dp__.getitem(_dp_ns, "b")=__dp__.getitem(_dp_ns, "a")):
         return value
-    f = _dp_add_binding("f", f)
+    __dp__.setitem(_dp_ns, "f", f)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
 $ nested class uses outer binding in bases
@@ -209,15 +206,15 @@ class Outer:
     class Inner(x):
         pass
 =
-def _dp_ns_Outer_Inner(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Outer.Inner")
-def _dp_ns_Outer(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Outer")
-    x = _dp_add_binding("x", 1)
-    _dp_tmp_1 = __dp__.global_(globals(), "__dp__").create_class("Inner", _dp_ns_Outer_Inner, (x,), None)
-    Inner = _dp_add_binding("Inner", _dp_tmp_1)
+def _dp_ns_Outer_Inner(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Outer.Inner")
+def _dp_ns_Outer(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Outer")
+    __dp__.setitem(_dp_ns, "x", 1)
+    _dp_tmp_1 = __dp__.create_class("Inner", _dp_ns_Outer_Inner, (__dp__.getitem(_dp_ns, "x"),), None)
+    __dp__.setitem(_dp_ns, "Inner", _dp_tmp_1)
 _dp_class_Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
 Outer = _dp_class_Outer
 $ function local class remains scoped
@@ -228,19 +225,19 @@ class Example:
             pass
         return Token
 =
-def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Example")
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
 
     def trigger(self):
 
-        def _dp_ns_Example_trigger__locals__Token(_dp_prepare_ns, _dp_add_binding):
-            _dp_add_binding("__module__", __name__)
-            _dp_add_binding("__qualname__", "Example.trigger.<locals>.Token")
+        def _dp_ns_Example_trigger__locals__Token(_dp_ns):
+            __dp__.setitem(_dp_ns, "__module__", __name__)
+            __dp__.setitem(_dp_ns, "__qualname__", "Example.trigger.<locals>.Token")
         _dp_class_Example_trigger__locals__Token = __dp__.create_class("Token", _dp_ns_Example_trigger__locals__Token, (), None)
         Token = _dp_class_Example_trigger__locals__Token
         return Token
-    trigger = _dp_add_binding("trigger", trigger)
+    __dp__.setitem(_dp_ns, "trigger", trigger)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
 $ function local class nested in if
@@ -253,26 +250,21 @@ class Example:
             return Token
         return None
 =
-def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Example")
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
 
     def trigger(self, flag):
-
         if flag:
-            def _dp_ns_Example_trigger__locals__Token(_dp_prepare_ns, _dp_add_binding):
-                _dp_add_binding("__module__", __name__)
-                _dp_add_binding("__qualname__", "Example.trigger.<locals>.Token")
-            _dp_class_Example_trigger__locals__Token = __dp__.create_class(
-                "Token",
-                _dp_ns_Example_trigger__locals__Token,
-                (),
-                None,
-            )
+
+            def _dp_ns_Example_trigger__locals__Token(_dp_ns):
+                __dp__.setitem(_dp_ns, "__module__", __name__)
+                __dp__.setitem(_dp_ns, "__qualname__", "Example.trigger.<locals>.Token")
+            _dp_class_Example_trigger__locals__Token = __dp__.create_class("Token", _dp_ns_Example_trigger__locals__Token, (), None)
             Token = _dp_class_Example_trigger__locals__Token
             return Token
         return None
-    trigger = _dp_add_binding("trigger", trigger)
+    __dp__.setitem(_dp_ns, "trigger", trigger)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
 $ function local methods capture locals
@@ -289,13 +281,13 @@ def outer():
 def outer():
     value = 1
 
-    def _dp_ns_outer__locals__C(_dp_prepare_ns, _dp_add_binding):
-        _dp_add_binding("__module__", __name__)
-        _dp_add_binding("__qualname__", "outer.<locals>.C")
+    def _dp_ns_outer__locals__C(_dp_ns):
+        __dp__.setitem(_dp_ns, "__module__", __name__)
+        __dp__.setitem(_dp_ns, "__qualname__", "outer.<locals>.C")
 
         def method(self):
             return value
-        method = _dp_add_binding("method", method)
+        __dp__.setitem(_dp_ns, "method", method)
     _dp_class_outer__locals__C = __dp__.create_class("C", _dp_ns_outer__locals__C, (), None)
     C = _dp_class_outer__locals__C
     return C

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -27,9 +27,9 @@ class C:
     pass
 =
 _dp_decorator__dp_class_C_0 = dec
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 _dp_class_C = _dp_decorator__dp_class_C_0(_dp_class_C)
 C = _dp_class_C
@@ -42,9 +42,9 @@ class C:
 =
 _dp_decorator__dp_class_C_0 = dec2(5)
 _dp_decorator__dp_class_C_1 = dec1
-def _dp_ns_C(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "C")
+def _dp_ns_C(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "C")
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 _dp_class_C = _dp_decorator__dp_class_C_0(_dp_decorator__dp_class_C_1(_dp_class_C))
 C = _dp_class_C

--- a/tests/integration_modules/test_class_attr_default.txt
+++ b/tests/integration_modules/test_class_attr_default.txt
@@ -7,14 +7,14 @@ class Example:
         return value
 =
 import __dp__
-def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Example")
-    _dp_tmp_1 = __dp__.global_(globals(), "object")()
-    SENTINEL = _dp_add_binding("SENTINEL", _dp_tmp_1)
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
+    _dp_tmp_1 = object()
+    __dp__.setitem(_dp_ns, "SENTINEL", _dp_tmp_1)
 
-    def method(self, value=SENTINEL):
+    def method(self, value=__dp__.getitem(_dp_ns, "SENTINEL")):
         return value
-    method = _dp_add_binding("method", method)
+    __dp__.setitem(_dp_ns, "method", method)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example

--- a/tests/integration_modules/test_comprehension_scope_shadowing.txt
+++ b/tests/integration_modules/test_comprehension_scope_shadowing.txt
@@ -13,13 +13,13 @@ FUNCTION_MEMBERS = [Scope.Function for scope in Scope if scope is Scope.Function
 =
 import __dp__
 Enum = __dp__.import_("enum", __spec__, __dp__.list(("Enum",))).Enum
-def _dp_ns_Scope(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Scope")
+def _dp_ns_Scope(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Scope")
     _dp_tmp_1 = "function"
-    Function = _dp_add_binding("Function", _dp_tmp_1)
+    __dp__.setitem(_dp_ns, "Function", _dp_tmp_1)
     _dp_tmp_2 = "module"
-    Module = _dp_add_binding("Module", _dp_tmp_2)
+    __dp__.setitem(_dp_ns, "Module", _dp_tmp_2)
 _dp_class_Scope = __dp__.create_class("Scope", _dp_ns_Scope, (Enum,), None)
 Scope = _dp_class_Scope
 def _dp_gen_3(_dp_iter_4):

--- a/tests/integration_modules/test_delattr_missing.txt
+++ b/tests/integration_modules/test_delattr_missing.txt
@@ -14,9 +14,9 @@ ATTRIBUTE_DELETED = not hasattr(INSTANCE, "value")
 =
 """Ensure the transform rewrites `del` to `__dp__.delattr` correctly."""
 import __dp__
-def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Example")
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
 INSTANCE = Example()

--- a/tests/integration_modules/test_dotted_import_alias_pkg____init__.txt
+++ b/tests/integration_modules/test_dotted_import_alias_pkg____init__.txt
@@ -1,4 +1,4 @@
-$ desugars dotted_import_alias_pkg/__init__
+$ desugars dotted_import_alias_pkg.__init__
 
 SENTINEL = "package"
 =

--- a/tests/integration_modules/test_dotted_import_alias_pkg__submodule.txt
+++ b/tests/integration_modules/test_dotted_import_alias_pkg__submodule.txt
@@ -1,4 +1,4 @@
-$ desugars dotted_import_alias_pkg/submodule
+$ desugars dotted_import_alias_pkg.submodule
 
 SENTINEL = "submodule"
 =

--- a/tests/integration_modules/test_generic_module.txt
+++ b/tests/integration_modules/test_generic_module.txt
@@ -20,16 +20,16 @@ import __dp__
 Generic = __dp__.import_("typing", __spec__, __dp__.list(("Generic",))).Generic
 TypeVar = __dp__.import_("typing", __spec__, __dp__.list(("TypeVar",))).TypeVar
 T = TypeVar("T")
-def _dp_ns_Box(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Box")
+def _dp_ns_Box(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Box")
 _dp_class_Box = __dp__.create_class("Box", _dp_ns_Box, (__dp__.getitem(Generic, T),), None)
 Box = _dp_class_Box
 def make_specialization():
 
-    def _dp_ns_make_specialization__locals__IntBox(_dp_prepare_ns, _dp_add_binding):
-        _dp_add_binding("__module__", __name__)
-        _dp_add_binding("__qualname__", "make_specialization.<locals>.IntBox")
+    def _dp_ns_make_specialization__locals__IntBox(_dp_ns):
+        __dp__.setitem(_dp_ns, "__module__", __name__)
+        __dp__.setitem(_dp_ns, "__qualname__", "make_specialization.<locals>.IntBox")
     _dp_class_make_specialization__locals__IntBox = __dp__.create_class("IntBox", _dp_ns_make_specialization__locals__IntBox, (__dp__.getitem(Box, int),), None)
     IntBox = _dp_class_make_specialization__locals__IntBox
     return IntBox

--- a/tests/integration_modules/test_generic_namedtuple_fields.txt
+++ b/tests/integration_modules/test_generic_namedtuple_fields.txt
@@ -44,16 +44,16 @@ if __dp__.not_(_dp_tmp_1):
 if _dp_tmp_1:
     _dp_decorator__dp_class_CaptureResult_0 = final
 
-    def _dp_ns_CaptureResult(_dp_prepare_ns, _dp_add_binding):
-        _dp_add_binding("__module__", __name__)
-        _dp_add_binding("__qualname__", "CaptureResult")
+    def _dp_ns_CaptureResult(_dp_ns):
+        __dp__.setitem(_dp_ns, "__module__", __name__)
+        __dp__.setitem(_dp_ns, "__qualname__", "CaptureResult")
         _dp_tmp_2 = """The result of the capture helper."""
-        __doc__ = _dp_add_binding("__doc__", _dp_tmp_2)
-        _dp_class_annotations = _dp_prepare_ns.get("__annotations__")
+        __dp__.setitem(_dp_ns, "__doc__", _dp_tmp_2)
+        _dp_class_annotations = _dp_ns.get("__annotations__")
         _dp_tmp_5 = __dp__.is_(_dp_class_annotations, None)
         if _dp_tmp_5:
             _dp_class_annotations = __dp__.dict()
-        _dp_add_binding("__annotations__", _dp_class_annotations)
+        __dp__.setitem(_dp_ns, "__annotations__", _dp_class_annotations)
         _dp_tmp_3 = "AnyStr"
         __dp__.setitem(_dp_class_annotations, "out", _dp_tmp_3)
         _dp_tmp_4 = "AnyStr"
@@ -63,11 +63,11 @@ if _dp_tmp_1:
     CaptureResult = _dp_class_CaptureResult
 else:
 
-    def _dp_ns_CaptureResult(_dp_prepare_ns, _dp_add_binding):
-        _dp_add_binding("__module__", __name__)
-        _dp_add_binding("__qualname__", "CaptureResult")
+    def _dp_ns_CaptureResult(_dp_ns):
+        __dp__.setitem(_dp_ns, "__module__", __name__)
+        __dp__.setitem(_dp_ns, "__qualname__", "CaptureResult")
         _dp_tmp_6 = ()
-        __slots__ = _dp_add_binding("__slots__", _dp_tmp_6)
+        __dp__.setitem(_dp_ns, "__slots__", _dp_tmp_6)
     _dp_class_CaptureResult = __dp__.create_class("CaptureResult", _dp_ns_CaptureResult, (collections.namedtuple("CaptureResult", __dp__.list(("out", "err"))), __dp__.getitem(Generic, AnyStr)), None)
     CaptureResult = _dp_class_CaptureResult
 RESULT = CaptureResult("out", "err")

--- a/tests/integration_modules/test_method_docstring.txt
+++ b/tests/integration_modules/test_method_docstring.txt
@@ -20,14 +20,14 @@ def build_annotations(cls):
 build_help(Example)
 =
 import __dp__
-def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Example")
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
 
     def do_thing(self, value: int) -> int:
         """Example command."""
         return value
-    do_thing = _dp_add_binding("do_thing", do_thing)
+    __dp__.setitem(_dp_ns, "do_thing", do_thing)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
 def build_help(cls):

--- a/tests/integration_modules/test_method_name_clash.txt
+++ b/tests/integration_modules/test_method_name_clash.txt
@@ -11,21 +11,21 @@ class Example:
         return date()
 =
 import __dp__
-def _dp_ns_date(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "date")
+def _dp_ns_date(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "date")
     _dp_tmp_1 = ()
-    __slots__ = _dp_add_binding("__slots__", _dp_tmp_1)
+    __dp__.setitem(_dp_ns, "__slots__", _dp_tmp_1)
 _dp_class_date = __dp__.create_class("date", _dp_ns_date, (), None)
 date = _dp_class_date
-def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Example")
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
     _dp_tmp_2 = __dp__.global_(globals(), "date").__slots__
-    slots = _dp_add_binding("slots", _dp_tmp_2)
+    __dp__.setitem(_dp_ns, "slots", _dp_tmp_2)
 
     def date(self):
         return __dp__.global_(globals(), "date")()
-    date = _dp_add_binding("date", date)
+    __dp__.setitem(_dp_ns, "date", date)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example

--- a/tests/integration_modules/test_nested_classes.txt
+++ b/tests/integration_modules/test_nested_classes.txt
@@ -41,29 +41,29 @@ def record(tag: str):
         __dp__.setattr(cls, "applied_decorators", applied)
         return cls
     return decorator
-def _dp_ns_Outer_Mid_Inner_Leaf(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Outer.Mid.Inner.Leaf")
-def _dp_ns_Outer_Mid_Inner(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Outer.Mid.Inner")
+def _dp_ns_Outer_Mid_Inner_Leaf(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Outer.Mid.Inner.Leaf")
+def _dp_ns_Outer_Mid_Inner(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Outer.Mid.Inner")
     _dp_tmp_5 = "inner"
-    label = _dp_add_binding("label", _dp_tmp_5)
-    _dp_tmp_6 = __dp__.global_(globals(), "record")(__dp__.add(label, "_leaf"))(__dp__.global_(globals(), "__dp__").create_class("Leaf", _dp_ns_Outer_Mid_Inner_Leaf, (), None))
-    Leaf = _dp_add_binding("Leaf", _dp_tmp_6)
-def _dp_ns_Outer_Mid(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Outer.Mid")
+    __dp__.setitem(_dp_ns, "label", _dp_tmp_5)
+    _dp_tmp_6 = record(__dp__.add(__dp__.getitem(_dp_ns, "label"), "_leaf"))(__dp__.create_class("Leaf", _dp_ns_Outer_Mid_Inner_Leaf, (), None))
+    __dp__.setitem(_dp_ns, "Leaf", _dp_tmp_6)
+def _dp_ns_Outer_Mid(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Outer.Mid")
     _dp_tmp_3 = "mid"
-    label = _dp_add_binding("label", _dp_tmp_3)
-    _dp_tmp_4 = __dp__.global_(globals(), "record")(__dp__.add(label, "_inner"))(__dp__.global_(globals(), "record")("stack")(__dp__.global_(globals(), "__dp__").create_class("Inner", _dp_ns_Outer_Mid_Inner, (), None)))
-    Inner = _dp_add_binding("Inner", _dp_tmp_4)
-def _dp_ns_Outer(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Outer")
+    __dp__.setitem(_dp_ns, "label", _dp_tmp_3)
+    _dp_tmp_4 = record(__dp__.add(__dp__.getitem(_dp_ns, "label"), "_inner"))(record("stack")(__dp__.create_class("Inner", _dp_ns_Outer_Mid_Inner, (), None)))
+    __dp__.setitem(_dp_ns, "Inner", _dp_tmp_4)
+def _dp_ns_Outer(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Outer")
     _dp_tmp_1 = "outer"
-    label = _dp_add_binding("label", _dp_tmp_1)
-    _dp_tmp_2 = __dp__.global_(globals(), "record")(__dp__.add(label, "_mid"))(__dp__.global_(globals(), "__dp__").create_class("Mid", _dp_ns_Outer_Mid, (), None))
-    Mid = _dp_add_binding("Mid", _dp_tmp_2)
+    __dp__.setitem(_dp_ns, "label", _dp_tmp_1)
+    _dp_tmp_2 = record(__dp__.add(__dp__.getitem(_dp_ns, "label"), "_mid"))(__dp__.create_class("Mid", _dp_ns_Outer_Mid, (), None))
+    __dp__.setitem(_dp_ns, "Mid", _dp_tmp_2)
 _dp_class_Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
 Outer = _dp_class_Outer

--- a/tests/integration_modules/test_property_setter.txt
+++ b/tests/integration_modules/test_property_setter.txt
@@ -13,24 +13,24 @@ class Example:
         self._value = value
 =
 import __dp__
-def _dp_ns_Example(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Example")
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
 
     def __init__(self) -> None:
         __dp__.setattr(self, "_value", 0)
-    __init__ = _dp_add_binding("__init__", __init__)
-    _dp_decorator_value_0 = __dp__.global_(globals(), "property")
+    __dp__.setitem(_dp_ns, "__init__", __init__)
+    _dp_decorator_value_0 = property
 
     def value(self) -> int:
         return self._value
-    value = _dp_decorator_value_0(value)
-    value = _dp_add_binding("value", value)
-    _dp_decorator_value_0 = value.setter
+    __dp__.setitem(_dp_ns, "value", _dp_decorator_value_0(value))
+    __dp__.setitem(_dp_ns, "value", __dp__.getitem(_dp_ns, "value"))
+    _dp_decorator_value_0 = __dp__.getitem(_dp_ns, "value").setter
 
     def value(self, value: int) -> None:
         __dp__.setattr(self, "_value", value)
-    value = _dp_decorator_value_0(value)
-    value = _dp_add_binding("value", value)
+    __dp__.setitem(_dp_ns, "value", _dp_decorator_value_0(value))
+    __dp__.setitem(_dp_ns, "value", __dp__.getitem(_dp_ns, "value"))
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example

--- a/tests/integration_modules/test_type_checking_annotations.txt
+++ b/tests/integration_modules/test_type_checking_annotations.txt
@@ -17,13 +17,12 @@ class Marker:
 import __dp__
 TYPE_CHECKING = __dp__.import_("typing", __spec__, __dp__.list(("TYPE_CHECKING",))).TYPE_CHECKING
 SENTINEL = object()
-def _dp_ns_Marker(_dp_prepare_ns, _dp_add_binding):
-    _dp_add_binding("__module__", __name__)
-    _dp_add_binding("__qualname__", "Marker")
-    if __dp__.global_(globals(), "TYPE_CHECKING"):
-        typed_attr: "int"
-        other_attr: "str"
-    _dp_tmp_1 = __dp__.global_(globals(), "SENTINEL")
-    value = _dp_add_binding("value", _dp_tmp_1)
+def _dp_ns_Marker(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Marker")
+    if TYPE_CHECKING:
+        _dp_ns["typed_attr"]: "int"
+        _dp_ns["other_attr"]: "str"
+    __dp__.setitem(_dp_ns, "value", SENTINEL)
 _dp_class_Marker = __dp__.create_class("Marker", _dp_ns_Marker, (), None)
 Marker = _dp_class_Marker

--- a/tests/test_cpython_transform_failures.py
+++ b/tests/test_cpython_transform_failures.py
@@ -182,15 +182,16 @@ def probe() -> list[str]:
     assert hits == ["hit"]
 
 
-def test_class_scope_comprehension_raises_name_error(tmp_path: Path) -> None:
+def test_class_scope_comprehension_executes(tmp_path: Path) -> None:
     source = r"""
 class Example:
     values = [lc for lc in range(3)]
 """
 
-    with pytest.raises(NameError, match="lc"):
-        with transformed_module(tmp_path, "class_comprehension", source):
-            pass
+    with transformed_module(tmp_path, "class_comprehension", source) as module:
+        Example = module.Example
+
+    assert Example.values == [0, 1, 2]
 
 
 @pytest.mark.xfail(reason="Nested classes defined inside methods lose their __class__ binding; CPython's test_smtplib depends on this working")


### PR DESCRIPTION
## Summary
- wrap class namespace execution in a `_ClassNamespace` helper that proxies assignments and lookups
- update the class variable renamer to track pending method names, rewrite later loads to `_dp_ns`, and fall back to globals for unresolved pending names
- refresh class transform fixtures, integration snapshots, and regression tests to cover the new semantics and confirm class comprehensions run successfully

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d57dc227708324835abba629a5e321