### PR TITLE
Enable nested class super test

### DIFF
--- a/tests/test_cpython_transform_failures.py
+++ b/tests/test_cpython_transform_failures.py
@@ -194,7 +194,6 @@ class Example:
     assert Example.values == [0, 1, 2]
 
 
-@pytest.mark.xfail(reason="Nested classes defined inside methods lose their __class__ binding; CPython's test_smtplib depends on this working")
 def test_nested_class_super_preserves_class_cell(tmp_path: Path) -> None:
     source = r"""
 class Base:


### PR DESCRIPTION
## Summary
- enable `test_nested_class_super_preserves_class_cell` by removing the xfail marker

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5915b4a7483249d5e06de83b585b8