### PR TITLE
Remove namespace helpers from module globals

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -44,6 +44,8 @@ def _dp_ns_A(_dp_ns):
     __dp__.setitem(_dp_ns, "d", d)
 _dp_class_A = __dp__.create_class("A", _dp_ns_A, (), None)
 A = _dp_class_A
+del _dp_class_A
+del _dp_ns_A
 def ff():
     a = A()
     __dp__.setattr(a, "b", 5)

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -40,3 +40,5 @@ def _dp_ns_Foo(_dp_ns):
     __dp__.setitem(_dp_ns, "method", method)
 _dp_class_Foo = __dp__.create_class("Foo", _dp_ns_Foo, (), None)
 Foo = _dp_class_Foo
+del _dp_class_Foo
+del _dp_ns_Foo

--- a/src/transform/tests_rewrite_class_def.txt
+++ b/src/transform/tests_rewrite_class_def.txt
@@ -9,6 +9,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "x", 1)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ collects class annotations
 
 class C:
@@ -28,6 +30,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_class_annotations, "y", str)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ captures outer reference
 
 class C:
@@ -39,6 +43,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "x", x)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ captures names used in annotations
 
 T = object()
@@ -58,6 +64,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_class_annotations, "x", T)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ preserves class locals for references
 
 class C:
@@ -71,6 +79,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "y", __dp__.getitem(_dp_ns, "x"))
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ lowers inherits
 
 class C(B):
@@ -81,6 +91,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "__qualname__", "C")
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (B,), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ lowers with docstring and keywords
 
 class C(B, metaclass=Meta, kw=1):
@@ -95,6 +107,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "x", 2)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (B,), __dp__.dict((("metaclass", Meta), ("kw", 1))))
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ lowers method
 
 class C:
@@ -110,6 +124,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ rewrites super and class
 
 class C:
@@ -125,6 +141,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ rewrites super uses first arg
 
 class C:
@@ -140,6 +158,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ rewrites super without receiver
 
 class C:
@@ -155,6 +175,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "m", m)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ applies decorators in namespace
 
 class C:
@@ -178,6 +200,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "m", __dp__.getitem(_dp_ns, "m"))
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ renames class stores and uses
 
 class C:
@@ -198,6 +222,8 @@ def _dp_ns_C(_dp_ns):
     __dp__.setitem(_dp_ns, "f", f)
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ nested class uses outer binding in bases
 
 class Outer:
@@ -217,6 +243,8 @@ def _dp_ns_Outer(_dp_ns):
     __dp__.setitem(_dp_ns, "Inner", _dp_tmp_1)
 _dp_class_Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
 Outer = _dp_class_Outer
+del _dp_class_Outer
+del _dp_ns_Outer
 $ function local class remains scoped
 
 class Example:
@@ -236,10 +264,14 @@ def _dp_ns_Example(_dp_ns):
             __dp__.setitem(_dp_ns, "__qualname__", "Example.trigger.<locals>.Token")
         _dp_class_Example_trigger__locals__Token = __dp__.create_class("Token", _dp_ns_Example_trigger__locals__Token, (), None)
         Token = _dp_class_Example_trigger__locals__Token
+        del _dp_class_Example_trigger__locals__Token
+        del _dp_ns_Example_trigger__locals__Token
         return Token
     __dp__.setitem(_dp_ns, "trigger", trigger)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example
 $ function local class nested in if
 
 class Example:
@@ -262,11 +294,15 @@ def _dp_ns_Example(_dp_ns):
                 __dp__.setitem(_dp_ns, "__qualname__", "Example.trigger.<locals>.Token")
             _dp_class_Example_trigger__locals__Token = __dp__.create_class("Token", _dp_ns_Example_trigger__locals__Token, (), None)
             Token = _dp_class_Example_trigger__locals__Token
+            del _dp_class_Example_trigger__locals__Token
+            del _dp_ns_Example_trigger__locals__Token
             return Token
         return None
     __dp__.setitem(_dp_ns, "trigger", trigger)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example
 $ function local methods capture locals
 
 def outer():
@@ -290,4 +326,6 @@ def outer():
         __dp__.setitem(_dp_ns, "method", method)
     _dp_class_outer__locals__C = __dp__.create_class("C", _dp_ns_outer__locals__C, (), None)
     C = _dp_class_outer__locals__C
+    del _dp_class_outer__locals__C
+    del _dp_ns_outer__locals__C
     return C

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -33,6 +33,8 @@ def _dp_ns_C(_dp_ns):
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 _dp_class_C = _dp_decorator__dp_class_C_0(_dp_class_C)
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ rewrites multiple class decorators
 
 @dec2(5)
@@ -48,6 +50,8 @@ def _dp_ns_C(_dp_ns):
 _dp_class_C = __dp__.create_class("C", _dp_ns_C, (), None)
 _dp_class_C = _dp_decorator__dp_class_C_0(_dp_decorator__dp_class_C_1(_dp_class_C))
 C = _dp_class_C
+del _dp_class_C
+del _dp_ns_C
 $ preserves existing decorator targets
 
 atexit = property(lambda: None)

--- a/tests/integration_modules/test_class_attr_default.txt
+++ b/tests/integration_modules/test_class_attr_default.txt
@@ -18,3 +18,5 @@ def _dp_ns_Example(_dp_ns):
     __dp__.setitem(_dp_ns, "method", method)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example

--- a/tests/integration_modules/test_comprehension_scope_shadowing.txt
+++ b/tests/integration_modules/test_comprehension_scope_shadowing.txt
@@ -22,6 +22,8 @@ def _dp_ns_Scope(_dp_ns):
     __dp__.setitem(_dp_ns, "Module", _dp_tmp_2)
 _dp_class_Scope = __dp__.create_class("Scope", _dp_ns_Scope, (Enum,), None)
 Scope = _dp_class_Scope
+del _dp_class_Scope
+del _dp_ns_Scope
 def _dp_gen_3(_dp_iter_4):
     _dp_iter_5 = __dp__.iter(_dp_iter_4)
     while True:

--- a/tests/integration_modules/test_delattr_missing.txt
+++ b/tests/integration_modules/test_delattr_missing.txt
@@ -19,6 +19,8 @@ def _dp_ns_Example(_dp_ns):
     __dp__.setitem(_dp_ns, "__qualname__", "Example")
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example
 INSTANCE = Example()
 __dp__.setattr(INSTANCE, "value", 1)
 __dp__.delattr(INSTANCE, "value")

--- a/tests/integration_modules/test_generic_module.txt
+++ b/tests/integration_modules/test_generic_module.txt
@@ -25,6 +25,8 @@ def _dp_ns_Box(_dp_ns):
     __dp__.setitem(_dp_ns, "__qualname__", "Box")
 _dp_class_Box = __dp__.create_class("Box", _dp_ns_Box, (__dp__.getitem(Generic, T),), None)
 Box = _dp_class_Box
+del _dp_class_Box
+del _dp_ns_Box
 def make_specialization():
 
     def _dp_ns_make_specialization__locals__IntBox(_dp_ns):
@@ -32,4 +34,6 @@ def make_specialization():
         __dp__.setitem(_dp_ns, "__qualname__", "make_specialization.<locals>.IntBox")
     _dp_class_make_specialization__locals__IntBox = __dp__.create_class("IntBox", _dp_ns_make_specialization__locals__IntBox, (__dp__.getitem(Box, int),), None)
     IntBox = _dp_class_make_specialization__locals__IntBox
+    del _dp_class_make_specialization__locals__IntBox
+    del _dp_ns_make_specialization__locals__IntBox
     return IntBox

--- a/tests/integration_modules/test_generic_namedtuple_fields.txt
+++ b/tests/integration_modules/test_generic_namedtuple_fields.txt
@@ -61,6 +61,8 @@ if _dp_tmp_1:
     _dp_class_CaptureResult = __dp__.create_class("CaptureResult", _dp_ns_CaptureResult, (NamedTuple, __dp__.getitem(Generic, AnyStr)), None)
     _dp_class_CaptureResult = _dp_decorator__dp_class_CaptureResult_0(_dp_class_CaptureResult)
     CaptureResult = _dp_class_CaptureResult
+    del _dp_class_CaptureResult
+    del _dp_ns_CaptureResult
 else:
 
     def _dp_ns_CaptureResult(_dp_ns):
@@ -70,4 +72,6 @@ else:
         __dp__.setitem(_dp_ns, "__slots__", _dp_tmp_6)
     _dp_class_CaptureResult = __dp__.create_class("CaptureResult", _dp_ns_CaptureResult, (collections.namedtuple("CaptureResult", __dp__.list(("out", "err"))), __dp__.getitem(Generic, AnyStr)), None)
     CaptureResult = _dp_class_CaptureResult
+    del _dp_class_CaptureResult
+    del _dp_ns_CaptureResult
 RESULT = CaptureResult("out", "err")

--- a/tests/integration_modules/test_method_docstring.txt
+++ b/tests/integration_modules/test_method_docstring.txt
@@ -30,6 +30,8 @@ def _dp_ns_Example(_dp_ns):
     __dp__.setitem(_dp_ns, "do_thing", do_thing)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example
 def build_help(cls):
     _dp_iter_1 = __dp__.iter(("thing",))
     while True:

--- a/tests/integration_modules/test_method_name_clash.txt
+++ b/tests/integration_modules/test_method_name_clash.txt
@@ -18,6 +18,8 @@ def _dp_ns_date(_dp_ns):
     __dp__.setitem(_dp_ns, "__slots__", _dp_tmp_1)
 _dp_class_date = __dp__.create_class("date", _dp_ns_date, (), None)
 date = _dp_class_date
+del _dp_class_date
+del _dp_ns_date
 def _dp_ns_Example(_dp_ns):
     __dp__.setitem(_dp_ns, "__module__", __name__)
     __dp__.setitem(_dp_ns, "__qualname__", "Example")
@@ -29,3 +31,5 @@ def _dp_ns_Example(_dp_ns):
     __dp__.setitem(_dp_ns, "date", date)
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example

--- a/tests/integration_modules/test_nested_classes.txt
+++ b/tests/integration_modules/test_nested_classes.txt
@@ -67,3 +67,5 @@ def _dp_ns_Outer(_dp_ns):
     __dp__.setitem(_dp_ns, "Mid", _dp_tmp_2)
 _dp_class_Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
 Outer = _dp_class_Outer
+del _dp_class_Outer
+del _dp_ns_Outer

--- a/tests/integration_modules/test_property_setter.txt
+++ b/tests/integration_modules/test_property_setter.txt
@@ -34,3 +34,5 @@ def _dp_ns_Example(_dp_ns):
     __dp__.setitem(_dp_ns, "value", __dp__.getitem(_dp_ns, "value"))
 _dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example

--- a/tests/integration_modules/test_type_checking_annotations.txt
+++ b/tests/integration_modules/test_type_checking_annotations.txt
@@ -26,3 +26,5 @@ def _dp_ns_Marker(_dp_ns):
     __dp__.setitem(_dp_ns, "value", SENTINEL)
 _dp_class_Marker = __dp__.create_class("Marker", _dp_ns_Marker, (), None)
 Marker = _dp_class_Marker
+del _dp_class_Marker
+del _dp_ns_Marker

--- a/tests/test_cpython_transform_failures.py
+++ b/tests/test_cpython_transform_failures.py
@@ -273,7 +273,6 @@ def summarize() -> tuple[int, int]:
     assert summarize() == (2, 3)
 
 
-@pytest.mark.xfail(reason="Class attribute destructuring drops bindings; fractions.Fraction loses arithmetic methods")
 def test_class_attribute_unpacking_binds_each_name(tmp_path: Path) -> None:
     source = r"""
 class Example:
@@ -329,7 +328,6 @@ def collect_segments(data: bytes) -> list[bytes]:
     assert collect_segments(b"ab") == [b"a", b"ab", b"b"]
 
 
-@pytest.mark.xfail(reason="Helper bindings generated for class definitions leak into module namespaces")
 def test_helper_bindings_are_excluded_from_all(tmp_path: Path) -> None:
     source = r"""
 __all__ = ["Example"]


### PR DESCRIPTION
## Summary
- stop overwriting namespace helper __module__ attributes and instead delete helpers after class creation when the class binds in its scope
- refresh the desugared example along with transform and integration fixtures to include the new helper cleanup behaviour

## Testing
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d592e38b20832495cd7b2d4619942c