### PR TITLE
Rewrite class-body deletions to target namespace

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -148,6 +148,11 @@ class _ClassNamespace:
             return self._locals[name]
         return self._namespace[name]
 
+    def __delitem__(self, name):
+        if name in self._locals:
+            del self._locals[name]
+        del self._namespace[name]
+
     def get(self, name, default=None):
         if name in self._locals:
             return self._locals.get(name, default)

--- a/tests/integration_modules/class_attr_delete.py
+++ b/tests/integration_modules/class_attr_delete.py
@@ -1,0 +1,6 @@
+class Example:
+    value = 1
+    del value
+
+
+EXPECTS_VALUE = hasattr(Example, "value")

--- a/tests/integration_modules/test_class_attr_delete.txt
+++ b/tests/integration_modules/test_class_attr_delete.txt
@@ -1,0 +1,20 @@
+$ desugars class_attr_delete
+
+class Example:
+    value = 1
+    del value
+
+
+EXPECTS_VALUE = hasattr(Example, "value")
+=
+import __dp__
+def _dp_ns_Example(_dp_ns):
+    __dp__.setitem(_dp_ns, "__module__", __name__)
+    __dp__.setitem(_dp_ns, "__qualname__", "Example")
+    __dp__.setitem(_dp_ns, "value", 1)
+    __dp__.delitem(_dp_ns, "value")
+_dp_class_Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
+Example = _dp_class_Example
+del _dp_class_Example
+del _dp_ns_Example
+EXPECTS_VALUE = hasattr(Example, "value")

--- a/tests/test_class_attr_delete_integration.py
+++ b/tests/test_class_attr_delete_integration.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+def test_class_attr_delete_removes_attribute(run_integration_module):
+    with run_integration_module("class_attr_delete") as module:
+        assert module.EXPECTS_VALUE is False


### PR DESCRIPTION
## Summary
- ensure class-body `del` statements target the class namespace so the transform emits `__dp__.delitem`
- implement `__delitem__` on the namespace helper to propagate deletions to the underlying dict
- update the class attribute deletion integration snapshot and test to assert the attribute is removed

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d60478ebd88324a218b4dbb74b672d