### PR TITLE
Add diff output to transform test comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "serde_json",
+ "similar",
  "wasm-bindgen",
 ]
 
@@ -587,6 +588,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ruff_text_size = { git = "https://github.com/astral-sh/ruff", package = "ruff_te
 ruff_source_file = { git = "https://github.com/astral-sh/ruff", package = "ruff_source_file" }
 regex = "1"
 serde_json = "1"
+similar = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }


### PR DESCRIPTION
## Summary
- add the `similar` crate dependency so we can compute line-level diffs
- extend `assert_transform_eq_ex` to print a diff between the expected and actual transform output on failure

## Testing
- `cargo test` *(fails: transform::rewrite_class_def::tests::transform_fixture – existing fixture mismatch)*
- `pytest` *(fails: tests/test_integration_desugaring_snapshots.py::test_integration_desugaring_snapshots_are_current[fixture16] – existing snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c405234c8324901acba56d7fe1a9