### PR TITLE
Print diff for transform test failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "serde_json",
+ "similar",
  "wasm-bindgen",
 ]
 
@@ -587,6 +588,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ruff_text_size = { git = "https://github.com/astral-sh/ruff", package = "ruff_te
 ruff_source_file = { git = "https://github.com/astral-sh/ruff", package = "ruff_source_file" }
 regex = "1"
 serde_json = "1"
+similar = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -3,6 +3,7 @@ use ruff_python_parser::parse_module;
 
 use crate::transform::Options;
 use crate::{ruff_ast_to_string, transform_str_to_ruff_with_options};
+use similar::TextDiff;
 
 pub(crate) fn assert_transform_eq_ex(actual: &str, expected: &str, truthy: bool) {
     let options = Options {
@@ -24,8 +25,11 @@ pub(crate) fn assert_transform_eq_ex(actual: &str, expected: &str, truthy: bool)
     let expected_stmt: Vec<_> = expected_ast.iter().map(ComparableStmt::from).collect();
 
     if actual_stmt != expected_stmt {
-        let message = format!("expected:\n{expected}\nactual:\n{actual_str}");
-        panic!("{message}");
+        let diff = TextDiff::from_lines(expected, &actual_str)
+            .unified_diff()
+            .header("expected", "actual")
+            .to_string();
+        panic!("expected desugaring to match fixture:\n{diff}");
     }
 }
 


### PR DESCRIPTION
## Summary
- add the `similar` crate dependency to support diff generation
- show a unified diff between expected and actual output in `assert_transform_eq`

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2c957556c832496a70d6fab5e1bf2