### PR TITLE
Pass _dp_class_ns directly into class namespace builders

### DIFF
--- a/example_desugar.py
+++ b/example_desugar.py
@@ -5,9 +5,8 @@ _dp_tmp_1 = bar(1, 2)
 def add(a, b):
     return __dp__.add(a, b)
 add = foo(_dp_tmp_1(add))
-def _dp_ns_A(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "b", 1)
+def _dp_ns_A(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "b", 1)
 
     def __init__(self):
         __dp__.setattr(self, "arr", __dp__.list((1, 2, 3)))
@@ -36,8 +35,8 @@ def _dp_ns_A(_dp_ns):
                 break
             else:
                 print(i)
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "A")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "A")
 A = __dp__.create_class("A", _dp_ns_A, (), None)
 def ff():
     a = A()

--- a/src/transform/class_def/rewrite_class_vars.rs
+++ b/src/transform/class_def/rewrite_class_vars.rs
@@ -67,7 +67,7 @@ impl Transformer for ClassVarRenamer {
                     self.visit_expr(value);
                     // Mark stored after visiting value, in case you have x = x, where rhs is global
                     self.stored.insert(id.as_str().to_string());
-                    *target = py_expr!("__dp_class_ns__[{name:literal}]", name = id.as_str());
+                    *target = py_expr!("_dp_class_ns[{name:literal}]", name = id.as_str());
                 } else {
                     walk_stmt(self, stmt);
                     return;
@@ -98,7 +98,7 @@ impl Transformer for ClassVarRenamer {
                     let name_str = name.as_str();
                     if self.should_rewrite(name_str) {
                         if self.stored.contains(name_str) && !self.pending.contains(name_str) {
-                            *expr = py_expr!("__dp_class_ns__[{name:literal}]", name = name_str);
+                            *expr = py_expr!("_dp_class_ns[{name:literal}]", name = name_str);
                         } else if self.pending.contains(name_str)
                             && !self.assignment_targets.contains(name_str)
                         {

--- a/src/transform/class_def/tests_rewrite_class_def.txt
+++ b/src/transform/class_def/tests_rewrite_class_def.txt
@@ -3,11 +3,10 @@ $ lowers simple class
 class C:
     x = 1
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "x", 1)
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "x", 1)
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ collects class annotations
 
@@ -15,16 +14,15 @@ class C:
     x: int
     y: str = 1
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "y", 1)
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
-    __dp__.setitem(__dp_class_ns__, "_dp_class_annotations", _dp_ns.get("__annotations__"))
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "y", 1)
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "_dp_class_annotations", _dp_class_ns.get("__annotations__"))
     _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
     if _dp_tmp_1:
-        __dp__.setitem(__dp_class_ns__, "_dp_class_annotations", __dp__.dict())
-    __dp__.setitem(__dp_class_ns__, "__annotations__", _dp_class_annotations)
+        __dp__.setitem(_dp_class_ns, "_dp_class_annotations", __dp__.dict())
+    __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
     __dp__.setitem(_dp_class_annotations, "x", int)
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ captures outer reference
@@ -32,11 +30,10 @@ $ captures outer reference
 class C:
     x = x
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "x", x)
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "x", x)
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ captures names used in annotations
 
@@ -46,15 +43,14 @@ class C:
     x: T
 =
 T = object()
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
-    __dp__.setitem(__dp_class_ns__, "_dp_class_annotations", _dp_ns.get("__annotations__"))
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "_dp_class_annotations", _dp_class_ns.get("__annotations__"))
     _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
     if _dp_tmp_1:
-        __dp__.setitem(__dp_class_ns__, "_dp_class_annotations", __dp__.dict())
-    __dp__.setitem(__dp_class_ns__, "__annotations__", _dp_class_annotations)
+        __dp__.setitem(_dp_class_ns, "_dp_class_annotations", __dp__.dict())
+    __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
     __dp__.setitem(_dp_class_annotations, "x", T)
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ preserves class locals for references
@@ -63,22 +59,20 @@ class C:
     x = 1
     y = x
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "x", 1)
-    __dp__.setitem(__dp_class_ns__, "y", __dp__.getitem(__dp_class_ns__, "x"))
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "x", 1)
+    __dp__.setitem(_dp_class_ns, "y", __dp__.getitem(_dp_class_ns, "x"))
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ lowers inherits
 
 class C(B):
     pass
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (B,), None)
 $ lowers with docstring and keywords
 
@@ -86,12 +80,11 @@ class C(B, metaclass=Meta, kw=1):
     'doc'
     x = 2
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__doc__", 'doc')
-    __dp__.setitem(__dp_class_ns__, "x", 2)
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__doc__", 'doc')
+    __dp__.setitem(_dp_class_ns, "x", 2)
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (B,), __dp__.dict((("metaclass", Meta), ("kw", 1))))
 $ lowers method
 
@@ -99,13 +92,12 @@ class C:
     def m(self):
         return 1
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_C(_dp_class_ns):
 
     def m(self):
         return 1
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ rewrites super and class
 
@@ -113,13 +105,12 @@ class C:
     def m(self):
         return super().m()
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_C(_dp_class_ns):
 
     def m(self):
         return super(C, self).m()
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ rewrites super uses first arg
 
@@ -127,13 +118,12 @@ class C:
     def m(z):
         return super().m()
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_C(_dp_class_ns):
 
     def m(z):
         return super(C, z).m()
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ rewrites super without receiver
 
@@ -141,13 +131,12 @@ class C:
     def m():
         return super().m()
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_C(_dp_class_ns):
 
     def m():
         return super(C, None).m()
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ applies decorators in namespace
 
@@ -159,16 +148,15 @@ class C:
     def m(self):
         return self
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "y", deco)
-    __dp__.setitem(__dp_class_ns__, "_dp_tmp_1", decorator(__dp__.getitem(__dp_class_ns__, "y")))
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "y", deco)
+    __dp__.setitem(_dp_class_ns, "_dp_tmp_1", decorator(__dp__.getitem(_dp_class_ns, "y")))
 
     def m(self):
         return self
-    __dp__.setitem(__dp_class_ns__, "m", _dp_tmp_1(other(__dp__.global_(globals(), "m"))))
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "m", _dp_tmp_1(other(__dp__.global_(globals(), "m"))))
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ renames class stores and uses
 
@@ -179,15 +167,14 @@ class C:
     def f(self, value: b = a):
         return value
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "a", 1)
-    __dp__.setitem(__dp_class_ns__, "b", __dp__.getitem(__dp_class_ns__, "a"))
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "a", 1)
+    __dp__.setitem(_dp_class_ns, "b", __dp__.getitem(_dp_class_ns, "a"))
 
-    def f(self, value: __dp__.getitem(__dp_class_ns__, "b")=__dp__.getitem(__dp_class_ns__, "a")):
+    def f(self, value: __dp__.getitem(_dp_class_ns, "b")=__dp__.getitem(_dp_class_ns, "a")):
         return value
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 $ nested class uses outer binding in bases
 
@@ -197,17 +184,15 @@ class Outer:
     class Inner(x):
         pass
 =
-def _dp_ns_Outer(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "x", 1)
-    __dp__.setitem(__dp_class_ns__, "Inner", __dp__.create_class("Inner", _dp_ns_Outer_Inner, (__dp__.getitem(__dp_class_ns__, "x"),), None))
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Outer")
+def _dp_ns_Outer(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "x", 1)
+    __dp__.setitem(_dp_class_ns, "Inner", __dp__.create_class("Inner", _dp_ns_Outer_Inner, (__dp__.getitem(_dp_class_ns, "x"),), None))
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer")
 Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
-def _dp_ns_Outer_Inner(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Outer.Inner")
+def _dp_ns_Outer_Inner(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Inner")
 Inner = __dp__.create_class("Inner", _dp_ns_Outer_Inner, (x,), None)
 $ function local class remains scoped
 
@@ -217,19 +202,17 @@ class Example:
             pass
         return Token
 =
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_Example(_dp_class_ns):
 
     def trigger(self):
 
-        def _dp_ns_trigger__locals__Token(_dp_ns):
-            __dp_class_ns__ = _dp_ns
-            __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-            __dp__.setitem(__dp_class_ns__, "__qualname__", "trigger.<locals>.Token")
+        def _dp_ns_trigger__locals__Token(_dp_class_ns):
+            __dp__.setitem(_dp_class_ns, "__module__", __name__)
+            __dp__.setitem(_dp_class_ns, "__qualname__", "trigger.<locals>.Token")
         Token = __dp__.create_class("Token", _dp_ns_trigger__locals__Token, (), None)
         return Token
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 $ function local class nested in if
 
@@ -241,21 +224,19 @@ class Example:
             return Token
         return None
 =
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_Example(_dp_class_ns):
 
     def trigger(self, flag):
         if flag:
 
-            def _dp_ns_trigger__locals__Token(_dp_ns):
-                __dp_class_ns__ = _dp_ns
-                __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-                __dp__.setitem(__dp_class_ns__, "__qualname__", "trigger.<locals>.Token")
+            def _dp_ns_trigger__locals__Token(_dp_class_ns):
+                __dp__.setitem(_dp_class_ns, "__module__", __name__)
+                __dp__.setitem(_dp_class_ns, "__qualname__", "trigger.<locals>.Token")
             Token = __dp__.create_class("Token", _dp_ns_trigger__locals__Token, (), None)
             return Token
         return None
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 $ function local methods capture locals
 
@@ -271,12 +252,11 @@ def outer():
 def outer():
     value = 1
 
-    def _dp_ns_outer__locals__C(_dp_ns):
-        __dp_class_ns__ = _dp_ns
+    def _dp_ns_outer__locals__C(_dp_class_ns):
 
         def method(self):
             return value
-        __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-        __dp__.setitem(__dp_class_ns__, "__qualname__", "outer.<locals>.C")
+        __dp__.setitem(_dp_class_ns, "__module__", __name__)
+        __dp__.setitem(_dp_class_ns, "__qualname__", "outer.<locals>.C")
     C = __dp__.create_class("C", _dp_ns_outer__locals__C, (), None)
     return C

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -31,11 +31,10 @@ class Foo:
     def method(self):
         return 1
 =
-def _dp_ns_Foo(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_Foo(_dp_class_ns):
 
     def method(self):
         return 1
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Foo")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Foo")
 Foo = __dp__.create_class("Foo", _dp_ns_Foo, (), None)

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -24,10 +24,9 @@ $ rewrites class decorators
 class C:
     pass
 =
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = dec(C)
 $ rewrites multiple class decorators
@@ -38,10 +37,9 @@ class C:
     pass
 =
 _dp_tmp_1 = dec2(5)
-def _dp_ns_C(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "C")
+def _dp_ns_C(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_tmp_1(dec1(C))
 $ preserves existing decorator targets

--- a/tests/integration_modules/test_class_attr_default.txt
+++ b/tests/integration_modules/test_class_attr_default.txt
@@ -7,12 +7,11 @@ class Example:
         return value
 =
 import __dp__
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "SENTINEL", object())
+def _dp_ns_Example(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "SENTINEL", object())
 
-    def method(self, value=__dp__.getitem(__dp_class_ns__, "SENTINEL")):
+    def method(self, value=__dp__.getitem(_dp_class_ns, "SENTINEL")):
         return value
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)

--- a/tests/integration_modules/test_class_attr_delete.txt
+++ b/tests/integration_modules/test_class_attr_delete.txt
@@ -8,11 +8,10 @@ class Example:
 EXPECTS_VALUE = hasattr(Example, "value")
 =
 import __dp__
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "value", 1)
+def _dp_ns_Example(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "value", 1)
     del value
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 EXPECTS_VALUE = hasattr(Example, "value")

--- a/tests/integration_modules/test_comprehension_scope_shadowing.txt
+++ b/tests/integration_modules/test_comprehension_scope_shadowing.txt
@@ -13,12 +13,11 @@ FUNCTION_MEMBERS = [Scope.Function for scope in Scope if scope is Scope.Function
 =
 import __dp__
 Enum = __dp__.import_("enum", __spec__, __dp__.list(("Enum",))).Enum
-def _dp_ns_Scope(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "Function", "function")
-    __dp__.setitem(__dp_class_ns__, "Module", "module")
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Scope")
+def _dp_ns_Scope(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "Function", "function")
+    __dp__.setitem(_dp_class_ns, "Module", "module")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Scope")
 Scope = __dp__.create_class("Scope", _dp_ns_Scope, (Enum,), None)
 def _dp_gen_1(_dp_iter_2):
     _dp_iter_3 = __dp__.iter(_dp_iter_2)

--- a/tests/integration_modules/test_delattr_missing.txt
+++ b/tests/integration_modules/test_delattr_missing.txt
@@ -14,10 +14,9 @@ ATTRIBUTE_DELETED = not hasattr(INSTANCE, "value")
 =
 """Ensure the transform rewrites `del` to `__dp__.delattr` correctly."""
 import __dp__
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+def _dp_ns_Example(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 INSTANCE = Example()
 __dp__.setattr(INSTANCE, "value", 1)

--- a/tests/integration_modules/test_generic_module.txt
+++ b/tests/integration_modules/test_generic_module.txt
@@ -20,16 +20,14 @@ import __dp__
 Generic = __dp__.import_("typing", __spec__, __dp__.list(("Generic",))).Generic
 TypeVar = __dp__.import_("typing", __spec__, __dp__.list(("TypeVar",))).TypeVar
 T = TypeVar("T")
-def _dp_ns_Box(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Box")
+def _dp_ns_Box(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Box")
 Box = __dp__.create_class("Box", _dp_ns_Box, (__dp__.getitem(Generic, T),), None)
 def make_specialization():
 
-    def _dp_ns_make_specialization__locals__IntBox(_dp_ns):
-        __dp_class_ns__ = _dp_ns
-        __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-        __dp__.setitem(__dp_class_ns__, "__qualname__", "make_specialization.<locals>.IntBox")
+    def _dp_ns_make_specialization__locals__IntBox(_dp_class_ns):
+        __dp__.setitem(_dp_class_ns, "__module__", __name__)
+        __dp__.setitem(_dp_class_ns, "__qualname__", "make_specialization.<locals>.IntBox")
     IntBox = __dp__.create_class("IntBox", _dp_ns_make_specialization__locals__IntBox, (__dp__.getitem(Box, int),), None)
     return IntBox

--- a/tests/integration_modules/test_generic_namedtuple_fields.txt
+++ b/tests/integration_modules/test_generic_namedtuple_fields.txt
@@ -43,26 +43,24 @@ if __dp__.not_(_dp_tmp_1):
     _dp_tmp_1 = TYPE_CHECKING
 if _dp_tmp_1:
 
-    def _dp_ns_CaptureResult(_dp_ns):
-        __dp_class_ns__ = _dp_ns
-        __dp__.setitem(__dp_class_ns__, "__doc__", """The result of the capture helper.""")
-        __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-        __dp__.setitem(__dp_class_ns__, "__qualname__", "CaptureResult")
-        __dp__.setitem(__dp_class_ns__, "_dp_class_annotations", _dp_ns.get("__annotations__"))
+    def _dp_ns_CaptureResult(_dp_class_ns):
+        __dp__.setitem(_dp_class_ns, "__doc__", """The result of the capture helper.""")
+        __dp__.setitem(_dp_class_ns, "__module__", __name__)
+        __dp__.setitem(_dp_class_ns, "__qualname__", "CaptureResult")
+        __dp__.setitem(_dp_class_ns, "_dp_class_annotations", _dp_class_ns.get("__annotations__"))
         _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
         if _dp_tmp_2:
-            __dp__.setitem(__dp_class_ns__, "_dp_class_annotations", __dp__.dict())
-        __dp__.setitem(__dp_class_ns__, "__annotations__", _dp_class_annotations)
+            __dp__.setitem(_dp_class_ns, "_dp_class_annotations", __dp__.dict())
+        __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
         __dp__.setitem(_dp_class_annotations, "out", "AnyStr")
         __dp__.setitem(_dp_class_annotations, "err", "AnyStr")
     CaptureResult = __dp__.create_class("CaptureResult", _dp_ns_CaptureResult, (NamedTuple, __dp__.getitem(Generic, AnyStr)), None)
     CaptureResult = final(CaptureResult)
 else:
 
-    def _dp_ns_CaptureResult(_dp_ns):
-        __dp_class_ns__ = _dp_ns
-        __dp__.setitem(__dp_class_ns__, "__slots__", ())
-        __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-        __dp__.setitem(__dp_class_ns__, "__qualname__", "CaptureResult")
+    def _dp_ns_CaptureResult(_dp_class_ns):
+        __dp__.setitem(_dp_class_ns, "__slots__", ())
+        __dp__.setitem(_dp_class_ns, "__module__", __name__)
+        __dp__.setitem(_dp_class_ns, "__qualname__", "CaptureResult")
     CaptureResult = __dp__.create_class("CaptureResult", _dp_ns_CaptureResult, (collections.namedtuple("CaptureResult", __dp__.list(("out", "err"))), __dp__.getitem(Generic, AnyStr)), None)
 RESULT = CaptureResult("out", "err")

--- a/tests/integration_modules/test_method_docstring.txt
+++ b/tests/integration_modules/test_method_docstring.txt
@@ -20,14 +20,13 @@ def build_annotations(cls):
 build_help(Example)
 =
 import __dp__
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_Example(_dp_class_ns):
 
     def do_thing(self, value: int) -> int:
         """Example command."""
         return value
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 def build_help(cls):
     _dp_iter_1 = __dp__.iter(("thing",))

--- a/tests/integration_modules/test_method_name_clash.txt
+++ b/tests/integration_modules/test_method_name_clash.txt
@@ -11,18 +11,16 @@ class Example:
         return date()
 =
 import __dp__
-def _dp_ns_date(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__slots__", ())
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "date")
+def _dp_ns_date(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__slots__", ())
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "date")
 date = __dp__.create_class("date", _dp_ns_date, (), None)
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "slots", date.__slots__)
+def _dp_ns_Example(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "slots", date.__slots__)
 
     def date(self):
         return __dp__.global_(globals(), "date")()
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)

--- a/tests/integration_modules/test_nested_classes.txt
+++ b/tests/integration_modules/test_nested_classes.txt
@@ -41,29 +41,25 @@ def record(tag: str):
         __dp__.setattr(cls, "applied_decorators", applied)
         return cls
     return decorator
-def _dp_ns_Outer(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "label", "outer")
-    __dp__.setitem(__dp_class_ns__, "Mid", record(__dp__.add(__dp__.getitem(__dp_class_ns__, "label"), "_mid"))(__dp__.create_class("Mid", _dp_ns_Outer_Mid, (), None)))
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Outer")
+def _dp_ns_Outer(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "label", "outer")
+    __dp__.setitem(_dp_class_ns, "Mid", record(__dp__.add(__dp__.getitem(_dp_class_ns, "label"), "_mid"))(__dp__.create_class("Mid", _dp_ns_Outer_Mid, (), None)))
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer")
 Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
-def _dp_ns_Outer_Mid(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "label", "mid")
-    __dp__.setitem(__dp_class_ns__, "Inner", record(__dp__.add(__dp__.getitem(__dp_class_ns__, "label"), "_inner"))(record("stack")(__dp__.create_class("Inner", _dp_ns_Outer_Mid_Inner, (), None))))
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Outer.Mid")
+def _dp_ns_Outer_Mid(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "label", "mid")
+    __dp__.setitem(_dp_class_ns, "Inner", record(__dp__.add(__dp__.getitem(_dp_class_ns, "label"), "_inner"))(record("stack")(__dp__.create_class("Inner", _dp_ns_Outer_Mid_Inner, (), None))))
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Mid")
 Mid = __dp__.create_class("Mid", _dp_ns_Outer_Mid, (), None)
-def _dp_ns_Outer_Mid_Inner(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "label", "inner")
-    __dp__.setitem(__dp_class_ns__, "Leaf", record(__dp__.add(__dp__.getitem(__dp_class_ns__, "label"), "_leaf"))(__dp__.create_class("Leaf", _dp_ns_Outer_Mid_Inner_Leaf, (), None)))
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Outer.Mid.Inner")
+def _dp_ns_Outer_Mid_Inner(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "label", "inner")
+    __dp__.setitem(_dp_class_ns, "Leaf", record(__dp__.add(__dp__.getitem(_dp_class_ns, "label"), "_leaf"))(__dp__.create_class("Leaf", _dp_ns_Outer_Mid_Inner_Leaf, (), None)))
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Mid.Inner")
 Inner = __dp__.create_class("Inner", _dp_ns_Outer_Mid_Inner, (), None)
-def _dp_ns_Outer_Mid_Inner_Leaf(_dp_ns):
-    __dp_class_ns__ = _dp_ns
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Outer.Mid.Inner.Leaf")
+def _dp_ns_Outer_Mid_Inner_Leaf(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Mid.Inner.Leaf")
 Leaf = __dp__.create_class("Leaf", _dp_ns_Outer_Mid_Inner_Leaf, (), None)

--- a/tests/integration_modules/test_property_setter.txt
+++ b/tests/integration_modules/test_property_setter.txt
@@ -13,20 +13,19 @@ class Example:
         self._value = value
 =
 import __dp__
-def _dp_ns_Example(_dp_ns):
-    __dp_class_ns__ = _dp_ns
+def _dp_ns_Example(_dp_class_ns):
 
     def __init__(self) -> None:
         __dp__.setattr(self, "_value", 0)
 
     def value(self) -> int:
         return self._value
-    __dp__.setitem(__dp_class_ns__, "value", property(__dp__.global_(globals(), "value")))
-    __dp__.setitem(__dp_class_ns__, "_dp_tmp_1", __dp__.global_(globals(), "value").setter)
+    __dp__.setitem(_dp_class_ns, "value", property(__dp__.global_(globals(), "value")))
+    __dp__.setitem(_dp_class_ns, "_dp_tmp_1", __dp__.global_(globals(), "value").setter)
 
     def value(self, value: int) -> None:
         __dp__.setattr(self, "_value", value)
-    __dp__.setitem(__dp_class_ns__, "value", _dp_tmp_1(__dp__.global_(globals(), "value")))
-    __dp__.setitem(__dp_class_ns__, "__module__", __name__)
-    __dp__.setitem(__dp_class_ns__, "__qualname__", "Example")
+    __dp__.setitem(_dp_class_ns, "value", _dp_tmp_1(__dp__.global_(globals(), "value")))
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)

--- a/tests/integration_modules/test_type_checking_annotations.txt
+++ b/tests/integration_modules/test_type_checking_annotations.txt
@@ -17,7 +17,7 @@ class Marker:
 import __dp__
 TYPE_CHECKING = __dp__.import_("typing", __spec__, __dp__.list(("TYPE_CHECKING",))).TYPE_CHECKING
 SENTINEL = object()
-def _dp_ns_Marker(_dp_ns):
+def _dp_ns_Marker(_dp_class_ns):
     __dp__.setitem(_dp_ns, "__module__", __name__)
     __dp__.setitem(_dp_ns, "__qualname__", "Marker")
     if TYPE_CHECKING:


### PR DESCRIPTION
## Summary
- have the class definition transform accept `_dp_class_ns` directly when building class namespace functions
- refresh the desugared example along with transform and integration fixtures to match the new parameter signature

## Testing
- cargo test
- pytest *(fails: existing integration failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f0b6f1208324b78a8f2b2b06425d