### PR TITLE
Switch class namespace transform to attribute access

### DIFF
--- a/__dp__.py
+++ b/__dp__.py
@@ -138,6 +138,25 @@ class _ClassNamespace:
         self._namespace = namespace
         self._locals = {}
 
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name, value):
+        if name in self.__slots__:
+            return super().__setattr__(name, value)
+        self[name] = value
+
+    def __delattr__(self, name):
+        if name in self.__slots__:
+            return super().__delattr__(name)
+        try:
+            del self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
     def __setitem__(self, name, value):
         setitem(self._locals, name, value)
         setitem(self._namespace, name, value)

--- a/example_desugar.py
+++ b/example_desugar.py
@@ -6,15 +6,15 @@ def add(a, b):
     return __dp__.add(a, b)
 add = foo(_dp_tmp_1(add))
 def _dp_ns_A(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "b", 1)
+    __dp__.setattr(_dp_class_ns, "b", 1)
 
     def __init__(self):
         __dp__.setattr(self, "arr", __dp__.list((1, 2, 3)))
-    __dp__.setitem(_dp_class_ns, "__init__", __init__)
+    __dp__.setattr(_dp_class_ns, "__init__", __init__)
 
     def c(self, d):
         return add(d, 2)
-    __dp__.setitem(_dp_class_ns, "c", c)
+    __dp__.setattr(_dp_class_ns, "c", c)
 
     async def test_aiter(self):
         _dp_iter_2 = __dp__.iter(range(10))
@@ -26,7 +26,7 @@ def _dp_ns_A(_dp_class_ns):
                 break
             else:
                 yield i
-    __dp__.setitem(_dp_class_ns, "test_aiter", test_aiter)
+    __dp__.setattr(_dp_class_ns, "test_aiter", test_aiter)
 
     async def d(self):
         _dp_iter_3 = __dp__.aiter(self.test_aiter())
@@ -38,9 +38,9 @@ def _dp_ns_A(_dp_class_ns):
                 break
             else:
                 print(i)
-    __dp__.setitem(_dp_class_ns, "d", d)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "A")
+    __dp__.setattr(_dp_class_ns, "d", d)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "A")
 A = __dp__.create_class("A", _dp_ns_A, (), None)
 del _dp_ns_A
 def ff():

--- a/src/transform/class_def/mod.rs
+++ b/src/transform/class_def/mod.rs
@@ -263,9 +263,9 @@ class C:
 def _dp_ns_C(_dp_class_ns):
     def m():
         return super(C, None).m()
-    __dp__.setitem(_dp_class_ns, "m", m)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "m", m)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 "#,

--- a/src/transform/class_def/tests_rewrite_class_def.txt
+++ b/src/transform/class_def/tests_rewrite_class_def.txt
@@ -4,9 +4,9 @@ class C:
     x = 1
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "x", 1)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "x", 1)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ rewrites class del statements
@@ -16,10 +16,10 @@ class C:
     del x
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "x", 1)
-    __dp__.delitem(_dp_class_ns, "x")
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "x", 1)
+    __dp__.delattr(_dp_class_ns, "x")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ collects class annotations
@@ -29,14 +29,14 @@ class C:
     y: str = 1
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "y", 1)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "y", 1)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
     _dp_class_annotations = _dp_class_ns.get("__annotations__")
     _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
     if _dp_tmp_1:
         _dp_class_annotations = __dp__.dict()
-    __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setattr(_dp_class_ns, "__annotations__", _dp_class_annotations)
     __dp__.setitem(_dp_class_annotations, "x", int)
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
@@ -46,9 +46,9 @@ class C:
     x = x
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "x", x)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "x", x)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ captures names used in annotations
@@ -60,13 +60,13 @@ class C:
 =
 T = object()
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
     _dp_class_annotations = _dp_class_ns.get("__annotations__")
     _dp_tmp_1 = __dp__.is_(_dp_class_annotations, None)
     if _dp_tmp_1:
         _dp_class_annotations = __dp__.dict()
-    __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setattr(_dp_class_ns, "__annotations__", _dp_class_annotations)
     __dp__.setitem(_dp_class_annotations, "x", T)
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
@@ -77,10 +77,10 @@ class C:
     y = x
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "x", 1)
-    __dp__.setitem(_dp_class_ns, "y", __dp__.getitem(_dp_class_ns, "x"))
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "x", 1)
+    __dp__.setattr(_dp_class_ns, "y", _dp_class_ns.x)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ lowers inherits
@@ -89,8 +89,8 @@ class C(B):
     pass
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (B,), None)
 del _dp_ns_C
 $ lowers with docstring and keywords
@@ -100,10 +100,10 @@ class C(B, metaclass=Meta, kw=1):
     x = 2
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__doc__", 'doc')
-    __dp__.setitem(_dp_class_ns, "x", 2)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "__doc__", 'doc')
+    __dp__.setattr(_dp_class_ns, "x", 2)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (B,), __dp__.dict((("metaclass", Meta), ("kw", 1))))
 del _dp_ns_C
 $ lowers method
@@ -116,9 +116,9 @@ def _dp_ns_C(_dp_class_ns):
 
     def m(self):
         return 1
-    __dp__.setitem(_dp_class_ns, "m", m)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "m", m)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ lowers async method
@@ -131,9 +131,9 @@ def _dp_ns_C(_dp_class_ns):
 
     async def m(self):
         return 1
-    __dp__.setitem(_dp_class_ns, "m", m)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "m", m)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ rewrites super and class
@@ -146,9 +146,9 @@ def _dp_ns_C(_dp_class_ns):
 
     def m(self):
         return super(C, self).m()
-    __dp__.setitem(_dp_class_ns, "m", m)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "m", m)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ rewrites super uses first arg
@@ -161,9 +161,9 @@ def _dp_ns_C(_dp_class_ns):
 
     def m(z):
         return super(C, z).m()
-    __dp__.setitem(_dp_class_ns, "m", m)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "m", m)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ rewrites super without receiver
@@ -176,9 +176,9 @@ def _dp_ns_C(_dp_class_ns):
 
     def m():
         return super(C, None).m()
-    __dp__.setitem(_dp_class_ns, "m", m)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "m", m)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ applies decorators in namespace
@@ -192,15 +192,15 @@ class C:
         return self
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "y", deco)
-    _dp_tmp_1 = decorator(__dp__.getitem(_dp_class_ns, "y"))
+    __dp__.setattr(_dp_class_ns, "y", deco)
+    _dp_tmp_1 = decorator(_dp_class_ns.y)
 
     def m(self):
         return self
-    __dp__.setitem(_dp_class_ns, "m", m)
-    __dp__.setitem(_dp_class_ns, "m", _dp_tmp_1(other(__dp__.getitem(_dp_class_ns, "m"))))
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "m", m)
+    __dp__.setattr(_dp_class_ns, "m", _dp_tmp_1(other(_dp_class_ns.m)))
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ renames class stores and uses
@@ -213,14 +213,14 @@ class C:
         return value
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "a", 1)
-    __dp__.setitem(_dp_class_ns, "b", __dp__.getitem(_dp_class_ns, "a"))
+    __dp__.setattr(_dp_class_ns, "a", 1)
+    __dp__.setattr(_dp_class_ns, "b", _dp_class_ns.a)
 
-    def f(self, value: __dp__.getitem(_dp_class_ns, "b")=__dp__.getitem(_dp_class_ns, "a")):
+    def f(self, value: _dp_class_ns.b=_dp_class_ns.a):
         return value
-    __dp__.setitem(_dp_class_ns, "f", f)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "f", f)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ nested class uses outer binding in bases
@@ -232,13 +232,13 @@ class Outer:
         pass
 =
 def _dp_ns_Outer(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "x", 1)
-    __dp__.setitem(_dp_class_ns, "Inner", __dp__.create_class("Inner", _dp_ns_Outer_Inner, (__dp__.getitem(_dp_class_ns, "x"),), None))
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer")
+    __dp__.setattr(_dp_class_ns, "x", 1)
+    __dp__.setattr(_dp_class_ns, "Inner", __dp__.create_class("Inner", _dp_ns_Outer_Inner, (_dp_class_ns.x,), None))
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Outer")
 def _dp_ns_Outer_Inner(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Inner")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Outer.Inner")
 Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
 del _dp_ns_Outer_Inner
 del _dp_ns_Outer
@@ -255,14 +255,14 @@ def _dp_ns_Example(_dp_class_ns):
     def trigger(self):
 
         def _dp_ns_trigger__locals__Token(_dp_class_ns):
-            __dp__.setitem(_dp_class_ns, "__module__", __name__)
-            __dp__.setitem(_dp_class_ns, "__qualname__", "trigger.<locals>.Token")
+            __dp__.setattr(_dp_class_ns, "__module__", __name__)
+            __dp__.setattr(_dp_class_ns, "__qualname__", "trigger.<locals>.Token")
         Token = __dp__.create_class("Token", _dp_ns_trigger__locals__Token, (), None)
         del _dp_ns_trigger__locals__Token
         return Token
-    __dp__.setitem(_dp_class_ns, "trigger", trigger)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "trigger", trigger)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example
 $ function local class nested in if
@@ -281,15 +281,15 @@ def _dp_ns_Example(_dp_class_ns):
         if flag:
 
             def _dp_ns_trigger__locals__Token(_dp_class_ns):
-                __dp__.setitem(_dp_class_ns, "__module__", __name__)
-                __dp__.setitem(_dp_class_ns, "__qualname__", "trigger.<locals>.Token")
+                __dp__.setattr(_dp_class_ns, "__module__", __name__)
+                __dp__.setattr(_dp_class_ns, "__qualname__", "trigger.<locals>.Token")
             Token = __dp__.create_class("Token", _dp_ns_trigger__locals__Token, (), None)
             del _dp_ns_trigger__locals__Token
             return Token
         return None
-    __dp__.setitem(_dp_class_ns, "trigger", trigger)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "trigger", trigger)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example
 $ function local methods capture locals
@@ -310,9 +310,9 @@ def outer():
 
         def method(self):
             return value
-        __dp__.setitem(_dp_class_ns, "method", method)
-        __dp__.setitem(_dp_class_ns, "__module__", __name__)
-        __dp__.setitem(_dp_class_ns, "__qualname__", "outer.<locals>.C")
+        __dp__.setattr(_dp_class_ns, "method", method)
+        __dp__.setattr(_dp_class_ns, "__module__", __name__)
+        __dp__.setattr(_dp_class_ns, "__qualname__", "outer.<locals>.C")
     C = __dp__.create_class("C", _dp_ns_outer__locals__C, (), None)
     del _dp_ns_outer__locals__C
     return C

--- a/src/transform/tests_mod.txt
+++ b/src/transform/tests_mod.txt
@@ -35,8 +35,8 @@ def _dp_ns_Foo(_dp_class_ns):
 
     def method(self):
         return 1
-    __dp__.setitem(_dp_class_ns, "method", method)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Foo")
+    __dp__.setattr(_dp_class_ns, "method", method)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Foo")
 Foo = __dp__.create_class("Foo", _dp_ns_Foo, (), None)
 del _dp_ns_Foo

--- a/src/transform/tests_rewrite_decorator.txt
+++ b/src/transform/tests_rewrite_decorator.txt
@@ -25,8 +25,8 @@ class C:
     pass
 =
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = dec(C)
 del _dp_ns_C
@@ -39,8 +39,8 @@ class C:
 =
 _dp_tmp_1 = dec2(5)
 def _dp_ns_C(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "C")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "C")
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 C = _dp_tmp_1(dec1(C))
 del _dp_ns_C

--- a/tests/integration_modules/test_class_attr_default.txt
+++ b/tests/integration_modules/test_class_attr_default.txt
@@ -8,12 +8,12 @@ class Example:
 =
 import __dp__
 def _dp_ns_Example(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "SENTINEL", object())
+    __dp__.setattr(_dp_class_ns, "SENTINEL", object())
 
-    def method(self, value=__dp__.getitem(_dp_class_ns, "SENTINEL")):
+    def method(self, value=_dp_class_ns.SENTINEL):
         return value
-    __dp__.setitem(_dp_class_ns, "method", method)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "method", method)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example

--- a/tests/integration_modules/test_class_attr_delete.txt
+++ b/tests/integration_modules/test_class_attr_delete.txt
@@ -9,10 +9,10 @@ EXPECTS_VALUE = hasattr(Example, "value")
 =
 import __dp__
 def _dp_ns_Example(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "value", 1)
-    __dp__.delitem(_dp_class_ns, "value")
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "value", 1)
+    __dp__.delattr(_dp_class_ns, "value")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example
 EXPECTS_VALUE = hasattr(Example, "value")

--- a/tests/integration_modules/test_comprehension_scope_shadowing.txt
+++ b/tests/integration_modules/test_comprehension_scope_shadowing.txt
@@ -14,10 +14,10 @@ FUNCTION_MEMBERS = [Scope.Function for scope in Scope if scope is Scope.Function
 import __dp__
 Enum = __dp__.import_("enum", __spec__, __dp__.list(("Enum",))).Enum
 def _dp_ns_Scope(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "Function", "function")
-    __dp__.setitem(_dp_class_ns, "Module", "module")
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Scope")
+    __dp__.setattr(_dp_class_ns, "Function", "function")
+    __dp__.setattr(_dp_class_ns, "Module", "module")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Scope")
 Scope = __dp__.create_class("Scope", _dp_ns_Scope, (Enum,), None)
 del _dp_ns_Scope
 def _dp_gen_1(_dp_iter_2):

--- a/tests/integration_modules/test_delattr_missing.txt
+++ b/tests/integration_modules/test_delattr_missing.txt
@@ -15,8 +15,8 @@ ATTRIBUTE_DELETED = not hasattr(INSTANCE, "value")
 """Ensure the transform rewrites `del` to `__dp__.delattr` correctly."""
 import __dp__
 def _dp_ns_Example(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example
 INSTANCE = Example()

--- a/tests/integration_modules/test_generic_module.txt
+++ b/tests/integration_modules/test_generic_module.txt
@@ -21,15 +21,15 @@ Generic = __dp__.import_("typing", __spec__, __dp__.list(("Generic",))).Generic
 TypeVar = __dp__.import_("typing", __spec__, __dp__.list(("TypeVar",))).TypeVar
 T = TypeVar("T")
 def _dp_ns_Box(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Box")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Box")
 Box = __dp__.create_class("Box", _dp_ns_Box, (__dp__.getitem(Generic, T),), None)
 del _dp_ns_Box
 def make_specialization():
 
     def _dp_ns_make_specialization__locals__IntBox(_dp_class_ns):
-        __dp__.setitem(_dp_class_ns, "__module__", __name__)
-        __dp__.setitem(_dp_class_ns, "__qualname__", "make_specialization.<locals>.IntBox")
+        __dp__.setattr(_dp_class_ns, "__module__", __name__)
+        __dp__.setattr(_dp_class_ns, "__qualname__", "make_specialization.<locals>.IntBox")
     IntBox = __dp__.create_class("IntBox", _dp_ns_make_specialization__locals__IntBox, (__dp__.getitem(Box, int),), None)
     del _dp_ns_make_specialization__locals__IntBox
     return IntBox

--- a/tests/integration_modules/test_generic_namedtuple_fields.txt
+++ b/tests/integration_modules/test_generic_namedtuple_fields.txt
@@ -44,14 +44,14 @@ if __dp__.not_(_dp_tmp_1):
 if _dp_tmp_1:
 
     def _dp_ns_CaptureResult(_dp_class_ns):
-        __dp__.setitem(_dp_class_ns, "__doc__", """The result of the capture helper.""")
-        __dp__.setitem(_dp_class_ns, "__module__", __name__)
-        __dp__.setitem(_dp_class_ns, "__qualname__", "CaptureResult")
+        __dp__.setattr(_dp_class_ns, "__doc__", """The result of the capture helper.""")
+        __dp__.setattr(_dp_class_ns, "__module__", __name__)
+        __dp__.setattr(_dp_class_ns, "__qualname__", "CaptureResult")
         _dp_class_annotations = _dp_class_ns.get("__annotations__")
         _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
         if _dp_tmp_2:
             _dp_class_annotations = __dp__.dict()
-        __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
+        __dp__.setattr(_dp_class_ns, "__annotations__", _dp_class_annotations)
         __dp__.setitem(_dp_class_annotations, "out", "AnyStr")
         __dp__.setitem(_dp_class_annotations, "err", "AnyStr")
     CaptureResult = __dp__.create_class("CaptureResult", _dp_ns_CaptureResult, (NamedTuple, __dp__.getitem(Generic, AnyStr)), None)
@@ -60,9 +60,9 @@ if _dp_tmp_1:
 else:
 
     def _dp_ns_CaptureResult(_dp_class_ns):
-        __dp__.setitem(_dp_class_ns, "__slots__", ())
-        __dp__.setitem(_dp_class_ns, "__module__", __name__)
-        __dp__.setitem(_dp_class_ns, "__qualname__", "CaptureResult")
+        __dp__.setattr(_dp_class_ns, "__slots__", ())
+        __dp__.setattr(_dp_class_ns, "__module__", __name__)
+        __dp__.setattr(_dp_class_ns, "__qualname__", "CaptureResult")
     CaptureResult = __dp__.create_class("CaptureResult", _dp_ns_CaptureResult, (collections.namedtuple("CaptureResult", __dp__.list(("out", "err"))), __dp__.getitem(Generic, AnyStr)), None)
     del _dp_ns_CaptureResult
 RESULT = CaptureResult("out", "err")

--- a/tests/integration_modules/test_method_docstring.txt
+++ b/tests/integration_modules/test_method_docstring.txt
@@ -25,9 +25,9 @@ def _dp_ns_Example(_dp_class_ns):
     def do_thing(self, value: int) -> int:
         """Example command."""
         return value
-    __dp__.setitem(_dp_class_ns, "do_thing", do_thing)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "do_thing", do_thing)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example
 def build_help(cls):

--- a/tests/integration_modules/test_method_name_clash.txt
+++ b/tests/integration_modules/test_method_name_clash.txt
@@ -12,18 +12,18 @@ class Example:
 =
 import __dp__
 def _dp_ns_date(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__slots__", ())
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "date")
+    __dp__.setattr(_dp_class_ns, "__slots__", ())
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "date")
 date = __dp__.create_class("date", _dp_ns_date, (), None)
 del _dp_ns_date
 def _dp_ns_Example(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "slots", __dp__.global_(globals(), "date").__slots__)
+    __dp__.setattr(_dp_class_ns, "slots", __dp__.global_(globals(), "date").__slots__)
 
     def date(self):
         return __dp__.global_(globals(), "date")()
-    __dp__.setitem(_dp_class_ns, "date", date)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "date", date)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example

--- a/tests/integration_modules/test_nested_classes.txt
+++ b/tests/integration_modules/test_nested_classes.txt
@@ -42,23 +42,23 @@ def record(tag: str):
         return cls
     return decorator
 def _dp_ns_Outer(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "label", "outer")
-    __dp__.setitem(_dp_class_ns, "Mid", record(__dp__.add(__dp__.getitem(_dp_class_ns, "label"), "_mid"))(__dp__.create_class("Mid", _dp_ns_Outer_Mid, (), None)))
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer")
+    __dp__.setattr(_dp_class_ns, "label", "outer")
+    __dp__.setattr(_dp_class_ns, "Mid", record(__dp__.add(_dp_class_ns.label, "_mid"))(__dp__.create_class("Mid", _dp_ns_Outer_Mid, (), None)))
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Outer")
 def _dp_ns_Outer_Mid(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "label", "mid")
-    __dp__.setitem(_dp_class_ns, "Inner", record(__dp__.add(__dp__.getitem(_dp_class_ns, "label"), "_inner"))(record("stack")(__dp__.create_class("Inner", _dp_ns_Outer_Mid_Inner, (), None))))
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Mid")
+    __dp__.setattr(_dp_class_ns, "label", "mid")
+    __dp__.setattr(_dp_class_ns, "Inner", record(__dp__.add(_dp_class_ns.label, "_inner"))(record("stack")(__dp__.create_class("Inner", _dp_ns_Outer_Mid_Inner, (), None))))
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Outer.Mid")
 def _dp_ns_Outer_Mid_Inner(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "label", "inner")
-    __dp__.setitem(_dp_class_ns, "Leaf", record(__dp__.add(__dp__.getitem(_dp_class_ns, "label"), "_leaf"))(__dp__.create_class("Leaf", _dp_ns_Outer_Mid_Inner_Leaf, (), None)))
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Mid.Inner")
+    __dp__.setattr(_dp_class_ns, "label", "inner")
+    __dp__.setattr(_dp_class_ns, "Leaf", record(__dp__.add(_dp_class_ns.label, "_leaf"))(__dp__.create_class("Leaf", _dp_ns_Outer_Mid_Inner_Leaf, (), None)))
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Outer.Mid.Inner")
 def _dp_ns_Outer_Mid_Inner_Leaf(_dp_class_ns):
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Outer.Mid.Inner.Leaf")
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Outer.Mid.Inner.Leaf")
 Outer = __dp__.create_class("Outer", _dp_ns_Outer, (), None)
 del _dp_ns_Outer_Mid_Inner_Leaf
 del _dp_ns_Outer_Mid_Inner

--- a/tests/integration_modules/test_property_setter.txt
+++ b/tests/integration_modules/test_property_setter.txt
@@ -17,19 +17,19 @@ def _dp_ns_Example(_dp_class_ns):
 
     def __init__(self) -> None:
         __dp__.setattr(self, "_value", 0)
-    __dp__.setitem(_dp_class_ns, "__init__", __init__)
+    __dp__.setattr(_dp_class_ns, "__init__", __init__)
 
     def value(self) -> int:
         return self._value
-    __dp__.setitem(_dp_class_ns, "value", value)
-    __dp__.setitem(_dp_class_ns, "value", property(__dp__.getitem(_dp_class_ns, "value")))
-    _dp_tmp_1 = __dp__.getitem(_dp_class_ns, "value").setter
+    __dp__.setattr(_dp_class_ns, "value", value)
+    __dp__.setattr(_dp_class_ns, "value", property(_dp_class_ns.value))
+    _dp_tmp_1 = _dp_class_ns.value.setter
 
     def value(self, value: int) -> None:
         __dp__.setattr(self, "_value", value)
-    __dp__.setitem(_dp_class_ns, "value", value)
-    __dp__.setitem(_dp_class_ns, "value", _dp_tmp_1(__dp__.getitem(_dp_class_ns, "value")))
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    __dp__.setattr(_dp_class_ns, "value", value)
+    __dp__.setattr(_dp_class_ns, "value", _dp_tmp_1(_dp_class_ns.value))
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Example")
 Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
 del _dp_ns_Example

--- a/tests/integration_modules/test_type_checking_annotations.txt
+++ b/tests/integration_modules/test_type_checking_annotations.txt
@@ -21,8 +21,8 @@ def _dp_ns_Marker(_dp_class_ns):
     if TYPE_CHECKING:
         typed_attr: "int"
         other_attr: "str"
-    __dp__.setitem(_dp_class_ns, "value", SENTINEL)
-    __dp__.setitem(_dp_class_ns, "__module__", __name__)
-    __dp__.setitem(_dp_class_ns, "__qualname__", "Marker")
+    __dp__.setattr(_dp_class_ns, "value", SENTINEL)
+    __dp__.setattr(_dp_class_ns, "__module__", __name__)
+    __dp__.setattr(_dp_class_ns, "__qualname__", "Marker")
 Marker = __dp__.create_class("Marker", _dp_ns_Marker, (), None)
 del _dp_ns_Marker


### PR DESCRIPTION
## Summary
- update the class definition transform to publish names via attribute loads/stores on `_dp_class_ns`
- teach the runtime class namespace helper to support attribute accessors and refresh fixtures accordingly

## Testing
- cargo test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5e85c025883248642e21ca09e2681