### PR TITLE
Preserve annotations when rewriting annotated assignments

### DIFF
--- a/src/transform/class_def/tests_rewrite_class_def.txt
+++ b/src/transform/class_def/tests_rewrite_class_def.txt
@@ -38,6 +38,7 @@ def _dp_ns_C(_dp_class_ns):
         _dp_class_annotations = __dp__.dict()
     __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
     __dp__.setitem(_dp_class_annotations, "x", int)
+    __dp__.setitem(_dp_class_annotations, "y", str)
 C = __dp__.create_class("C", _dp_ns_C, (), None)
 del _dp_ns_C
 $ captures outer reference

--- a/src/transform/rewrite_assign_del.rs
+++ b/src/transform/rewrite_assign_del.rs
@@ -120,19 +120,17 @@ fn rewrite_unpack_target(
 
 pub(crate) fn rewrite_ann_assign(
     rewriter: &mut ExprRewriter,
-    ann_assign: ast::StmtAnnAssign,
+    mut ann_assign: ast::StmtAnnAssign,
 ) -> Rewrite {
-    let ast::StmtAnnAssign {
-        target,
-        value: Some(value),
-        ..
-    } = ann_assign
-    else {
+    let Some(value) = ann_assign.value.take() else {
         return Rewrite::Walk(vec![Stmt::AnnAssign(ann_assign)]);
     };
 
+    let target = (*ann_assign.target).clone();
+
     let mut stmts = Vec::new();
-    rewrite_target(rewriter, *target, *value, &mut stmts);
+    stmts.push(Stmt::AnnAssign(ann_assign));
+    rewrite_target(rewriter, target, *value, &mut stmts);
     Rewrite::Visit(stmts)
 }
 

--- a/src/transform/tests_expr.txt
+++ b/src/transform/tests_expr.txt
@@ -85,6 +85,7 @@ x: int
 $ expr 011
 x: int = 1
 =
+x: int
 x = 1
 
 $ expr 012

--- a/src/transform/tests_rewrite_assign_del.txt
+++ b/src/transform/tests_rewrite_assign_del.txt
@@ -2,6 +2,7 @@ $ rewrites annotated assignment with value
 
 x: int = 1
 =
+x: int
 x = 1
 
 $ rewrites chained assignment

--- a/tests/integration_modules/dataclass_slots_union_default.py
+++ b/tests/integration_modules/dataclass_slots_union_default.py
@@ -1,0 +1,12 @@
+import dataclasses
+
+
+@dataclasses.dataclass(slots=True)
+class Example:
+    label: str
+    state: str | None = None
+    count: int = 0
+
+
+def build_example(**kwargs):
+    return Example("label", **kwargs)

--- a/tests/integration_modules/test_dataclass_slots_union_default.txt
+++ b/tests/integration_modules/test_dataclass_slots_union_default.txt
@@ -1,0 +1,36 @@
+$ desugars dataclass_slots_union_default
+
+import dataclasses
+
+
+@dataclasses.dataclass(slots=True)
+class Example:
+    label: str
+    state: str | None = None
+    count: int = 0
+
+
+def build_example(**kwargs):
+    return Example("label", **kwargs)
+=
+import __dp__
+dataclasses = __dp__.import_("dataclasses", __spec__)
+_dp_tmp_1 = dataclasses.dataclass(slots=True)
+def _dp_ns_Example(_dp_class_ns):
+    __dp__.setitem(_dp_class_ns, "state", None)
+    __dp__.setitem(_dp_class_ns, "count", 0)
+    __dp__.setitem(_dp_class_ns, "__module__", __name__)
+    __dp__.setitem(_dp_class_ns, "__qualname__", "Example")
+    _dp_class_annotations = _dp_class_ns.get("__annotations__")
+    _dp_tmp_2 = __dp__.is_(_dp_class_annotations, None)
+    if _dp_tmp_2:
+        _dp_class_annotations = __dp__.dict()
+    __dp__.setitem(_dp_class_ns, "__annotations__", _dp_class_annotations)
+    __dp__.setitem(_dp_class_annotations, "label", str)
+    __dp__.setitem(_dp_class_annotations, "state", __dp__.or_(str, None))
+    __dp__.setitem(_dp_class_annotations, "count", int)
+Example = __dp__.create_class("Example", _dp_ns_Example, (), None)
+Example = _dp_tmp_1(Example)
+del _dp_ns_Example
+def build_example(**kwargs):
+    return Example("label", **kwargs)

--- a/tests/test_dataclass_slots_union_default_integration.py
+++ b/tests/test_dataclass_slots_union_default_integration.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_dataclass_slots_union_default_preserves_field_annotations(run_integration_module):
+    with run_integration_module("dataclass_slots_union_default") as module:
+        instance = module.build_example(state="ready", count=3)
+    assert instance.state == "ready"
+    assert instance.count == 3


### PR DESCRIPTION
## Summary
- split annotated assignments with defaults into a separate annotation statement and plain assignment so metadata survives later passes
- update transform fixtures and the dataclass integration snapshot to include the restored annotations
- enable the dataclass integration test now that keyword initialization works under the transform

## Testing
- pytest tests -q
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e5e8767cf88324b177f8429fe7d19d